### PR TITLE
Support rendering background color as icon color or label color in folder / thread / message / compose panes

### DIFF
--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1234,6 +1234,7 @@ var accountColorsAbout3Pane_115 = {
     threadRowIndexSetter: function(row) {
       var msgHdr, accountkey, account, accountidkey, folder, server, element;
       var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var coloringDisabled = false;
       var nonHiddenColumnFound = false;
 
       /* Call original function */
@@ -1263,11 +1264,17 @@ var accountColorsAbout3Pane_115 = {
         else accountidkey = account.defaultIdentity.key;
       }
 
+      /* Enable coloring only in Unified folder if specified */
+
+      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-color-unified-only")) {
+        coloringDisabled = !!window.gFolder && window.gFolder.server.hostName != "smart mailboxes";
+      }
+
       /* Set row properties */
 
       /* Color row background */
 
-      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd")) {
+      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd") && !coloringDisabled) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
         this.style.setProperty("--ac-bkgd-color", bkgdcolor);
       } else {
@@ -1292,7 +1299,7 @@ var accountColorsAbout3Pane_115 = {
         if (column.id == "subjectCol") {
           /* Color subject font */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont")) {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont") && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {
@@ -1358,7 +1365,7 @@ var accountColorsAbout3Pane_115 = {
         if (column.id == "senderCol") {
           /* Color from font */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom")) {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom") && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {
@@ -1424,7 +1431,7 @@ var accountColorsAbout3Pane_115 = {
         if (column.id == "correspondentCol") {
           /* Color recipient/date/size/account/etc fonts */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {
@@ -1437,7 +1444,7 @@ var accountColorsAbout3Pane_115 = {
         if (column.id == "accountCol") {
           /* Color recipient/date/size/account/etc fonts */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {
@@ -1457,7 +1464,7 @@ var accountColorsAbout3Pane_115 = {
 
         /* Color recipient/date/size/account/etc fonts */
 
-        if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
+        if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && !coloringDisabled) {
           fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
           element.style.setProperty("--ac-font-color", fontcolor);
         } else {
@@ -1471,6 +1478,7 @@ var accountColorsAbout3Pane_115 = {
     threadCardIndexSetter: function(row) {
       var msgHdr, accountkey, account, accountidkey, folder, server, element;
       var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var coloringDisabled = false;
 
       /* Call original function */
 
@@ -1499,11 +1507,17 @@ var accountColorsAbout3Pane_115 = {
         else accountidkey = account.defaultIdentity.key;
       }
 
+      /* Enable coloring only in Unified folder if specified */
+
+      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-color-unified-only")) {
+        coloringDisabled = !!window.gFolder && window.gFolder.server.hostName != "smart mailboxes";
+      }
+
       /* Set card properties */
 
       /* Color card background */
 
-      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd")) {
+      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd") && !coloringDisabled) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
         this.style.setProperty("--ac-bkgd-color", bkgdcolor);
       } else {
@@ -1516,7 +1530,7 @@ var accountColorsAbout3Pane_115 = {
 
           /* Color subject font */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont")) {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont") && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {
@@ -1584,10 +1598,10 @@ var accountColorsAbout3Pane_115 = {
 
           /* Color from / date font */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom") && column == "senderCol") {
+          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom") && column == "senderCol" && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
-          } else if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && column == "dateCol") {
+          } else if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && column == "dateCol" && !coloringDisabled) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
             element.style.setProperty("--ac-font-color", fontcolor);
           } else {

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -550,23 +550,27 @@ var accountColorsAbout3Pane_102 = {
 
           msgHdr = gDBView.getMsgHdrAt(row);
 
-          /* Color based on received account */
+          if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
+            accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+          } else {
+            /* Color based on received account */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
-            /* color using account in message header */
-            accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
-            account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
+            if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
+              /* color using account in message header */
+              accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
+              account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
 
-            if (account == null) accountidkey = null; /* sent message */
-            else if (account.defaultIdentity == null) accountidkey = account.key;
-            else accountidkey = account.defaultIdentity.key;
-          } /* color using account in which folder is located */ else {
-            folder = msgHdr.folder;
-            server = folder.server;
-            account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
+              if (account == null) accountidkey = null; /* sent message */
+              else if (account.defaultIdentity == null) accountidkey = account.key;
+              else accountidkey = account.defaultIdentity.key;
+            } /* color using account in which folder is located */ else {
+              folder = msgHdr.folder;
+              server = folder.server;
+              account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
 
-            if (account.defaultIdentity == null) accountidkey = account.key;
-            else accountidkey = account.defaultIdentity.key;
+              if (account.defaultIdentity == null) accountidkey = account.key;
+              else accountidkey = account.defaultIdentity.key;
+            }
           }
 
           /* add extra properties for not-hover, not-selected, not-focused, background color, show row stripes, darker selection bar */
@@ -614,23 +618,27 @@ var accountColorsAbout3Pane_102 = {
 
           msgHdr = gDBView.getMsgHdrAt(row);
 
-          /* Color based on received account */
+          if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
+            accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+          } else {
+            /* Color based on received account */
 
-          if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
-            /* color using account in message header */
-            accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
-            account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
+            if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
+              /* color using account in message header */
+              accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
+              account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
 
-            if (account == null) accountidkey = null; /* sent message */
-            else if (account.defaultIdentity == null) accountidkey = account.key;
-            else accountidkey = account.defaultIdentity.key;
-          } /* color using account in which folder is located */ else {
-            folder = msgHdr.folder;
-            server = folder.server;
-            account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
+              if (account == null) accountidkey = null; /* sent message */
+              else if (account.defaultIdentity == null) accountidkey = account.key;
+              else accountidkey = account.defaultIdentity.key;
+            } /* color using account in which folder is located */ else {
+              folder = msgHdr.folder;
+              server = folder.server;
+              account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
 
-            if (account.defaultIdentity == null) accountidkey = account.key;
-            else accountidkey = account.defaultIdentity.key;
+              if (account.defaultIdentity == null) accountidkey = account.key;
+              else accountidkey = account.defaultIdentity.key;
+            }
           }
 
           /* add extra properties for not-hover and not-selected */
@@ -1242,8 +1250,8 @@ var accountColorsAbout3Pane_115 = {
     /* Detour ThreadRow.prototype.index setter */
 
     threadRowIndexSetter: function(row) {
-      var msgHdr, accountkey, account, accountidkey, folder, server, element;
-      var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var msgHdr, account, accountidkey, element;
+      var fontcolor, bkgdcolor, fontstyle, fontsize;
       var coloringDisabled = false;
       var nonHiddenColumnFound = false;
 
@@ -1254,25 +1262,7 @@ var accountColorsAbout3Pane_115 = {
       }
 
       msgHdr = gDBView.getMsgHdrAt(row);
-
-      /* Color based on received account */
-
-      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
-        /* color using account in message header */
-        accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
-        account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
-
-        if (account == null) accountidkey = null; /* sent message */
-        else if (account.defaultIdentity == null) accountidkey = account.key;
-        else accountidkey = account.defaultIdentity.key;
-      } /* color using account in which folder is located */ else {
-        folder = msgHdr.folder;
-        server = folder.server;
-        account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
-
-        if (account.defaultIdentity == null) accountidkey = account.key;
-        else accountidkey = account.defaultIdentity.key;
-      }
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
 
       /* Enable coloring only in Unified folder if specified */
 
@@ -1442,8 +1432,8 @@ var accountColorsAbout3Pane_115 = {
     /* Detour ThreadCard.prototype.index setter */
 
     threadCardIndexSetter: function(row) {
-      var msgHdr, accountkey, account, accountidkey, folder, server, element;
-      var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var msgHdr, accountidkey, element;
+      var fontcolor, bkgdcolor, fontstyle, fontsize;
       var coloringDisabled = false;
 
       /* Call original function */
@@ -1453,25 +1443,7 @@ var accountColorsAbout3Pane_115 = {
       }
 
       msgHdr = gDBView.getMsgHdrAt(row);
-
-      /* Color based on received account */
-
-      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount")) {
-        /* color using account in message header */
-        accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
-        account = accountColorsAbout3Pane.accountManager.getAccount(accountkey);
-
-        if (account == null) accountidkey = null; /* sent message */
-        else if (account.defaultIdentity == null) accountidkey = account.key;
-        else accountidkey = account.defaultIdentity.key;
-      } /* color using account in which folder is located */ else {
-        folder = msgHdr.folder;
-        server = folder.server;
-        account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
-
-        if (account.defaultIdentity == null) accountidkey = account.key;
-        else accountidkey = account.defaultIdentity.key;
-      }
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
 
       /* Enable coloring only in Unified folder if specified */
 

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1050,7 +1050,7 @@ var accountColorsAbout3Pane_115 = {
         this.setIconColor(); // Restore default icon
       }
 
-      /* Color unread/total/size fonts */
+      /* Color unread/total/size font */
 
       if (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorother")) {
         fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
@@ -1061,6 +1061,19 @@ var accountColorsAbout3Pane_115 = {
         this.unreadCountLabel.style.removeProperty("--ac-font-color");
         this.totalCountLabel.style.removeProperty("--ac-font-color");
         this.folderSizeLabel.style.removeProperty("--ac-font-color");
+      }
+
+      /* Color unread/total/size background */
+
+      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorotherbkgd")) {
+        bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
+        this.unreadCountLabel.style.setProperty("--ac-badge-bkgd-color", bkgdcolor);
+        this.totalCountLabel.style.setProperty("--ac-badge-bkgd-color", bkgdcolor);
+        this.folderSizeLabel.style.setProperty("--ac-badge-bkgd-color", bkgdcolor);
+      } else {
+        this.unreadCountLabel.style.removeProperty("--ac-badge-bkgd-color");
+        this.totalCountLabel.style.removeProperty("--ac-badge-bkgd-color");
+        this.folderSizeLabel.style.removeProperty("--ac-badge-bkgd-color");
       }
 
       /* Account font style */

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -312,11 +312,15 @@ var accountColorsAbout3Pane_102 = {
         return props; // Unified Inbox row's _folder may be null
       }
 
-      server = gFolderTreeView._rowMap[row]._folder.server;
-      account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
+      if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
+        accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForFolder(gFolderTreeView._rowMap[row]._folder);
+      } else {
+        server = gFolderTreeView._rowMap[row]._folder.server;
+        account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
 
-      if (account.defaultIdentity == null) accountidkey = account.key;
-      else accountidkey = account.defaultIdentity.key;
+        if (account.defaultIdentity == null) accountidkey = account.key;
+        else accountidkey = account.defaultIdentity.key;
+      }
 
       /* add extra properties for not-hover, not-dragOn, not-selected, not-focused, background color, folder background color, and darker selection bar */
       /* required to select tree element styles defined in accountcolors-messengerwindow[-generated].css */
@@ -367,11 +371,15 @@ var accountColorsAbout3Pane_102 = {
         props = ""
       }
 
-      server = gFolderTreeView._rowMap[row]._folder.server;
-      account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
+      if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
+        accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForFolder(gFolderTreeView._rowMap[row]._folder);
+      } else {
+        server = gFolderTreeView._rowMap[row]._folder.server;
+        account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
 
-      if (account.defaultIdentity == null) accountidkey = account.key;
-      else accountidkey = account.defaultIdentity.key;
+        if (account.defaultIdentity == null) accountidkey = account.key;
+        else accountidkey = account.defaultIdentity.key;
+      }
 
       /* add extra properties for not-hover, not-dragOn, not-selected */
       /* required to select tree element styles defined in accountcolors-messengerwindow[-generated].css */
@@ -551,7 +559,7 @@ var accountColorsAbout3Pane_102 = {
           msgHdr = gDBView.getMsgHdrAt(row);
 
           if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
-            accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+            accountColorsUtilities.resolveAccountIdentityKeyForMessage(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
           } else {
             /* Color based on received account */
 
@@ -619,7 +627,7 @@ var accountColorsAbout3Pane_102 = {
           msgHdr = gDBView.getMsgHdrAt(row);
 
           if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
-            accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+            accountColorsUtilities.resolveAccountIdentityKeyForMessage(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
           } else {
             /* Color based on received account */
 
@@ -996,8 +1004,8 @@ var accountColorsAbout3Pane_115 = {
     /* Detour FolderTreeRow.prototype.setFolderPropertiesFromFolder */
 
     setFolderPropertiesFromFolder: function(folder) {
-      var server, account, accountidkey;
-      var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var accountidkey;
+      var fontcolor, bkgdcolor, fontstyle, fontsize;
 
       /* Call original function */
 
@@ -1010,11 +1018,7 @@ var accountColorsAbout3Pane_115 = {
         this.container = this.querySelector(".container");
       }
 
-      server = folder.server;
-      account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
-
-      if (account.defaultIdentity == null) accountidkey = account.key;
-      else accountidkey = account.defaultIdentity.key;
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForFolder(folder);
 
       /* Regard account folders in Unified Folders (Inbox/Drafts/etc.) as accounts */
 
@@ -1262,7 +1266,7 @@ var accountColorsAbout3Pane_115 = {
       }
 
       msgHdr = gDBView.getMsgHdrAt(row);
-      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForMessage(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
 
       /* Enable coloring only in Unified folder if specified */
 
@@ -1443,7 +1447,7 @@ var accountColorsAbout3Pane_115 = {
       }
 
       msgHdr = gDBView.getMsgHdrAt(row);
-      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForMessage(msgHdr, accountColorsAbout3Pane.prefs.getBoolPref("thread-hdraccount"));
 
       /* Enable coloring only in Unified folder if specified */
 

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1080,31 +1080,9 @@ var accountColorsAbout3Pane_115 = {
 
       if (accountColorsAbout3Pane.prefs.getBoolPref("folder-setfontstyle") && (folder.isServer || inUnifiedFolder)) {
         fontstyle = accountColorsAbout3Pane.prefs.getIntPref("folder-fontstyle");
-
-        switch (fontstyle) {
-          case 0 /* Normal */:
-            style = "normal";
-            weight = "normal";
-            break;
-          case 1 /* Italic */:
-            style = "italic";
-            weight = "normal";
-            break;
-          case 2 /* Bold */:
-            style = "normal";
-            weight = "bold";
-            break;
-          case 3 /* Bold Italic */:
-            style = "italic";
-            weight = "bold";
-            break;
-        }
-
-        this.nameLabel.style.setProperty("--ac-font-style", style);
-        this.nameLabel.style.setProperty("--ac-font-weight", weight);
+        this.nameLabel.setAttribute("ac-fsw", ["normal", "italic", "bold", "bolditalic"][fontstyle]);
       } else {
-        this.nameLabel.style.removeProperty("--ac-font-style");
-        this.nameLabel.style.removeProperty("--ac-font-weight");
+        this.nameLabel.removeAttribute("ac-fsw");
       }
 
       /* Account font size */
@@ -1342,31 +1320,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-setfontstyle")) {
             fontstyle = accountColorsAbout3Pane.prefs.getIntPref("thread-fontstyle");
-
-            switch (fontstyle) {
-              case 0 /* Normal */:
-                style = "normal";
-                weight = "normal";
-                break;
-              case 1 /* Italic */:
-                style = "italic";
-                weight = "normal";
-                break;
-              case 2 /* Bold */:
-                style = "normal";
-                weight = "bold";
-                break;
-              case 3 /* Bold Italic */:
-                style = "italic";
-                weight = "bold";
-                break;
-            }
-
-            element.style.setProperty("--ac-font-style", style);
-            element.style.setProperty("--ac-font-weight", weight);
+            element.setAttribute("ac-fsw", ["normal", "italic", "bold", "bolditalic"][fontstyle]);
           } else {
-            element.style.removeProperty("--ac-font-style");
-            element.style.removeProperty("--ac-font-weight");
+            element.removeAttribute("ac-fsw");
           }
 
           /* Subject font size */
@@ -1408,31 +1364,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-setfromstyle")) {
             fontstyle = accountColorsAbout3Pane.prefs.getIntPref("thread-fromstyle");
-
-            switch (fontstyle) {
-              case 0 /* Normal */:
-                style = "normal";
-                weight = "normal";
-                break;
-              case 1 /* Italic */:
-                style = "italic";
-                weight = "normal";
-                break;
-              case 2 /* Bold */:
-                style = "normal";
-                weight = "bold";
-                break;
-              case 3 /* Bold Italic */:
-                style = "italic";
-                weight = "bold";
-                break;
-            }
-
-            element.style.setProperty("--ac-font-style", style);
-            element.style.setProperty("--ac-font-weight", weight);
+            element.setAttribute("ac-fsw", ["normal", "italic", "bold", "bolditalic"][fontstyle]);
           } else {
-            element.style.removeProperty("--ac-font-style");
-            element.style.removeProperty("--ac-font-weight");
+            element.removeAttribute("ac-fsw");
           }
 
           /* From font size */
@@ -1573,31 +1507,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-setfontstyle")) {
             fontstyle = accountColorsAbout3Pane.prefs.getIntPref("thread-fontstyle");
-
-            switch (fontstyle) {
-              case 0 /* Normal */:
-                style = "normal";
-                weight = "normal";
-                break;
-              case 1 /* Italic */:
-                style = "italic";
-                weight = "normal";
-                break;
-              case 2 /* Bold */:
-                style = "normal";
-                weight = "bold";
-                break;
-              case 3 /* Bold Italic */:
-                style = "italic";
-                weight = "bold";
-                break;
-            }
-
-            element.style.setProperty("--ac-font-style", style);
-            element.style.setProperty("--ac-font-weight", weight);
+            element.setAttribute("ac-fsw", ["normal", "italic", "bold", "bolditalic"][fontstyle]);
           } else {
-            element.style.removeProperty("--ac-font-style");
-            element.style.removeProperty("--ac-font-weight");
+            element.removeAttribute("ac-fsw");
           }
 
           /* Subject font size */
@@ -1644,31 +1556,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-setfromstyle")) {
             fontstyle = accountColorsAbout3Pane.prefs.getIntPref("thread-fromstyle");
-
-            switch (fontstyle) {
-              case 0 /* Normal */:
-                style = "normal";
-                weight = "normal";
-                break;
-              case 1 /* Italic */:
-                style = "italic";
-                weight = "normal";
-                break;
-              case 2 /* Bold */:
-                style = "normal";
-                weight = "bold";
-                break;
-              case 3 /* Bold Italic */:
-                style = "italic";
-                weight = "bold";
-                break;
-            }
-
-            element.style.setProperty("--ac-font-style", style);
-            element.style.setProperty("--ac-font-weight", weight);
+            element.setAttribute("ac-fsw", ["normal", "italic", "bold", "bolditalic"][fontstyle]);
           } else {
-            element.style.removeProperty("--ac-font-style");
-            element.style.removeProperty("--ac-font-weight");
+            element.removeAttribute("ac-fsw");
           }
 
           /* From font size */

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1268,7 +1268,9 @@ var accountColorsAbout3Pane_115 = {
 
       if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd")) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
-        this.style.backgroundColor = bkgdcolor;
+        this.style.setProperty("--ac-bkgd-color", bkgdcolor);
+      } else {
+        this.style.removeProperty("--ac-bkgd-color");
       }
 
       /* Set column properties */
@@ -1286,9 +1288,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont")) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
           } else {
-            element.style.color = "";
+            element.style.removeProperty("--ac-font-color");
           }
 
           /* Subject font style */
@@ -1315,11 +1317,11 @@ var accountColorsAbout3Pane_115 = {
                 break;
             }
 
-            element.style.fontStyle = style;
-            element.style.fontWeight = weight;
+            element.style.setProperty("--ac-font-style", style);
+            element.style.setProperty("--ac-font-weight", weight);
           } else {
-            element.style.fontStyle = "";
-            element.style.fontWeight = "";
+            element.style.removeProperty("--ac-font-style");
+            element.style.removeProperty("--ac-font-weight");
           }
 
           /* Subject font size */
@@ -1352,9 +1354,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom")) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
           } else {
-            element.style.color = "";
+            element.style.removeProperty("--ac-font-color");
           }
 
           /* From font style */
@@ -1381,11 +1383,11 @@ var accountColorsAbout3Pane_115 = {
                 break;
             }
 
-            element.style.fontStyle = style;
-            element.style.fontWeight = weight;
+            element.style.setProperty("--ac-font-style", style);
+            element.style.setProperty("--ac-font-weight", weight);
           } else {
-            element.style.fontStyle = "";
-            element.style.fontWeight = "";
+            element.style.removeProperty("--ac-font-style");
+            element.style.removeProperty("--ac-font-weight");
           }
 
           /* From font size */
@@ -1418,7 +1420,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
+          } else {
+            element.style.removeProperty("--ac-font-color");
           }
 
           continue;
@@ -1429,7 +1433,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
+          } else {
+            element.style.removeProperty("--ac-font-color");
           }
 
           /* Color using account in message header */
@@ -1447,7 +1453,9 @@ var accountColorsAbout3Pane_115 = {
 
         if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother")) {
           fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-          element.style.color = fontcolor;
+          element.style.setProperty("--ac-font-color", fontcolor);
+        } else {
+          element.style.removeProperty("--ac-font-color");
         }
       }
     },
@@ -1491,7 +1499,9 @@ var accountColorsAbout3Pane_115 = {
 
       if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd")) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
-        this.style.backgroundColor = bkgdcolor;
+        this.style.setProperty("--ac-bkgd-color", bkgdcolor);
+      } else {
+        this.style.removeProperty("--ac-bkgd-color");
       }
 
       for (const column of window.threadPane.cardColumns) {
@@ -1502,9 +1512,9 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfont")) {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
           } else {
-            element.style.color = "";
+            element.style.removeProperty("--ac-font-color");
           }
 
           /* Subject font style */
@@ -1531,11 +1541,11 @@ var accountColorsAbout3Pane_115 = {
                 break;
             }
 
-            element.style.fontStyle = style;
-            element.style.fontWeight = weight;
+            element.style.setProperty("--ac-font-style", style);
+            element.style.setProperty("--ac-font-weight", weight);
           } else {
-            element.style.fontStyle = "";
-            element.style.fontWeight = "";
+            element.style.removeProperty("--ac-font-style");
+            element.style.removeProperty("--ac-font-weight");
           }
 
           /* Subject font size */
@@ -1570,12 +1580,12 @@ var accountColorsAbout3Pane_115 = {
 
           if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorfrom") && column == "senderCol") {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
           } else if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorother") && column == "dateCol") {
             fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-            element.style.color = fontcolor;
+            element.style.setProperty("--ac-font-color", fontcolor);
           } else {
-            element.style.color = "";
+            element.style.removeProperty("--ac-font-color");
           }
 
           /* From font style */
@@ -1602,11 +1612,11 @@ var accountColorsAbout3Pane_115 = {
                 break;
             }
 
-            element.style.fontStyle = style;
-            element.style.fontWeight = weight;
+            element.style.setProperty("--ac-font-style", style);
+            element.style.setProperty("--ac-font-weight", weight);
           } else {
-            element.style.fontStyle = "";
-            element.style.fontWeight = "";
+            element.style.removeProperty("--ac-font-style");
+            element.style.removeProperty("--ac-font-weight");
           }
 
           /* From font size */

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1234,6 +1234,7 @@ var accountColorsAbout3Pane_115 = {
     threadRowIndexSetter: function(row) {
       var msgHdr, accountkey, account, accountidkey, folder, server, element;
       var fontcolor, bkgdcolor, fontstyle, fontsize, style, weight;
+      var nonHiddenColumnFound = false;
 
       /* Call original function */
 
@@ -1282,6 +1283,11 @@ var accountColorsAbout3Pane_115 = {
 
         /* Set some element fields on ThreadRow object for modifying properties */
         element = this.querySelector("." + column.id.toLowerCase() + "-column");
+
+        if (!nonHiddenColumnFound) {
+          element.classList.add("ac-first-non-hidden-column");
+          nonHiddenColumnFound = true;
+        }
 
         if (column.id == "subjectCol") {
           /* Color subject font */
@@ -1713,6 +1719,42 @@ var accountColorsAbout3Pane_115 = {
     } else {
       element = accountColorsAbout3Pane.threadTree;
       element.removeAttribute("ac-hoverselect");
+    }
+
+    /* Color row background as label */
+
+    if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd-row-label")) {
+      element = accountColorsAbout3Pane.threadTree;
+      switch (accountColorsAbout3Pane.prefs.getIntPref("thread-row-label-position")) {
+        case 0: /* Subject Column */
+          element.setAttribute("ac-bkgdaslabel-row", "subjectCol");
+          break;
+        case 1: /* First Column */
+          element.setAttribute("ac-bkgdaslabel-row", "firstCol");
+          break;
+      }
+      element.style.setProperty("--ac-row-label-width", accountColorsAbout3Pane.prefs.getIntPref("thread-row-label-width") + "px");
+    } else {
+      element = accountColorsAbout3Pane.threadTree;
+      element.removeAttribute("ac-bkgdaslabel-row");
+      element.style.removeProperty("--ac-row-label-width");
+    }
+
+    if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd-card-label")) {
+      element = accountColorsAbout3Pane.threadTree;
+      switch (accountColorsAbout3Pane.prefs.getIntPref("thread-card-label-position")) {
+        case 0: /* No Indent */
+          element.setAttribute("ac-bkgdaslabel-card", "noindent");
+          break;
+        case 1: /* Indent */
+          element.setAttribute("ac-bkgdaslabel-card", "indent");
+          break;
+      }
+      element.style.setProperty("--ac-card-label-width", accountColorsAbout3Pane.prefs.getIntPref("thread-card-label-width") + "px");
+    } else {
+      element = accountColorsAbout3Pane.threadTree;
+      element.removeAttribute("ac-bkgdaslabel-card");
+      element.style.removeProperty("--ac-card-label-width");
     }
   },
 

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1023,17 +1023,31 @@ var accountColorsAbout3Pane_115 = {
         this.nameLabel.style.removeProperty("--ac-font-color");
       }
 
+      /* Render background color as icon color */
+
+      var colorBkgdAsIcon = accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd-account-icon") && (folder.isServer || inUnifiedFolder) ||
+                            accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd-folder-icon") && !folder.isServer;
+
       /* Color account/folders background */
 
       if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd") && (folder.isServer || inUnifiedFolder)) ||
           (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfldbkgd") && !folder.isServer)) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
 
-        if (!(accountColorsAbout3Pane.prefs.getBoolPref("folder-defaultbkgd") && bkgdcolor == "")) {
-          this.container.style.setProperty("--ac-bkgd-color", bkgdcolor);
+        if (!colorBkgdAsIcon) {
+          if (!(accountColorsAbout3Pane.prefs.getBoolPref("folder-defaultbkgd") && bkgdcolor == "")) {
+            this.container.style.setProperty("--ac-bkgd-color", bkgdcolor);
+          }
+          this.setIconColor(); // Restore default icon
+        } else {
+          if (!this.icon.style.getPropertyValue("--icon-color")) {
+            this.setIconColor(bkgdcolor);
+          }
+          this.container.style.removeProperty("--ac-bkgd-color");
         }
       } else {
         this.container.style.removeProperty("--ac-bkgd-color");
+        this.setIconColor(); // Restore default icon
       }
 
       /* Color unread/total/size fonts */

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1008,9 +1008,14 @@ var accountColorsAbout3Pane_115 = {
       if (account.defaultIdentity == null) accountidkey = account.key;
       else accountidkey = account.defaultIdentity.key;
 
+      /* Regard account folders in Unified Folders (Inbox/Drafts/etc.) as accounts */
+
+      var parentElement = this.parentNode.closest('li[is="folder-tree-row"]');
+      var inUnifiedFolder = parentElement && parentElement.uri.startsWith("mailbox://nobody@smart%20mailboxes");
+
       /* Color account/folders font */
 
-      if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfont") && folder.isServer) ||
+      if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfont") && (folder.isServer || inUnifiedFolder)) ||
           (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfldfont") && !folder.isServer)) {
         fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
         this.nameLabel.style.setProperty("--ac-font-color", fontcolor);
@@ -1020,7 +1025,7 @@ var accountColorsAbout3Pane_115 = {
 
       /* Color account/folders background */
 
-      if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd") && folder.isServer) ||
+      if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd") && (folder.isServer || inUnifiedFolder)) ||
           (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfldbkgd") && !folder.isServer)) {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
 
@@ -1046,7 +1051,7 @@ var accountColorsAbout3Pane_115 = {
 
       /* Account font style */
 
-      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-setfontstyle") && folder.isServer) {
+      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-setfontstyle") && (folder.isServer || inUnifiedFolder)) {
         fontstyle = accountColorsAbout3Pane.prefs.getIntPref("folder-fontstyle");
 
         switch (fontstyle) {
@@ -1077,7 +1082,7 @@ var accountColorsAbout3Pane_115 = {
 
       /* Account font size */
 
-      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-setfontsize") && folder.isServer) {
+      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-setfontsize") && (folder.isServer || inUnifiedFolder)) {
         fontsize = accountColorsAbout3Pane.prefs.getIntPref("folder-fontsize");
         // ac-fs have margin-top attribute set, we use it instead of font-size style
         if (accountColorsAbout3Pane.prefs.getBoolPref("folder-incspacing")) {

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1013,9 +1013,9 @@ var accountColorsAbout3Pane_115 = {
       if ((accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfont") && folder.isServer) ||
           (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorfldfont") && !folder.isServer)) {
         fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-        this.nameLabel.style.color = fontcolor;
+        this.nameLabel.style.setProperty("--ac-font-color", fontcolor);
       } else {
-        this.nameLabel.style.color = "";
+        this.nameLabel.style.removeProperty("--ac-font-color");
       }
 
       /* Color account/folders background */
@@ -1025,23 +1025,23 @@ var accountColorsAbout3Pane_115 = {
         bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
 
         if (!(accountColorsAbout3Pane.prefs.getBoolPref("folder-defaultbkgd") && bkgdcolor == "")) {
-          this.container.style.backgroundColor = bkgdcolor;
+          this.container.style.setProperty("--ac-bkgd-color", bkgdcolor);
         }
       } else {
-        this.container.style.backgroundColor = "";
+        this.container.style.removeProperty("--ac-bkgd-color");
       }
 
       /* Color unread/total/size fonts */
 
       if (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorother")) {
         fontcolor = accountColorsUtilities.fontColorPref(accountidkey);
-        this.unreadCountLabel.style.color = fontcolor;
-        this.totalCountLabel.style.color = fontcolor;
-        this.folderSizeLabel.style.color = fontcolor;
+        this.unreadCountLabel.style.setProperty("--ac-font-color", fontcolor);
+        this.totalCountLabel.style.setProperty("--ac-font-color", fontcolor);
+        this.folderSizeLabel.style.setProperty("--ac-font-color", fontcolor);
       } else {
-        this.unreadCountLabel.style.color = "";
-        this.totalCountLabel.style.color = "";
-        this.folderSizeLabel.style.color = "";
+        this.unreadCountLabel.style.removeProperty("--ac-font-color");
+        this.totalCountLabel.style.removeProperty("--ac-font-color");
+        this.folderSizeLabel.style.removeProperty("--ac-font-color");
       }
 
       /* Account font style */
@@ -1068,11 +1068,11 @@ var accountColorsAbout3Pane_115 = {
             break;
         }
 
-        this.nameLabel.style.fontStyle = style;
-        this.nameLabel.style.fontWeight = weight;
+        this.nameLabel.style.setProperty("--ac-font-style", style);
+        this.nameLabel.style.setProperty("--ac-font-weight", weight);
       } else {
-        this.nameLabel.style.fontStyle = "";
-        this.nameLabel.style.fontWeight = "";
+        this.nameLabel.style.removeProperty("--ac-font-style");
+        this.nameLabel.style.removeProperty("--ac-font-weight");
       }
 
       /* Account font size */

--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1010,8 +1010,8 @@ var accountColorsAbout3Pane_115 = {
 
       /* Regard account folders in Unified Folders (Inbox/Drafts/etc.) as accounts */
 
-      var parentElement = this.parentNode.closest('li[is="folder-tree-row"]');
-      var inUnifiedFolder = parentElement && parentElement.uri.startsWith("mailbox://nobody@smart%20mailboxes");
+      var parentElement = this.parentNode && this.parentNode.closest('li[is="folder-tree-row"]');
+      var inUnifiedFolder = !!parentElement && parentElement.uri.startsWith("mailbox://nobody@smart%20mailboxes");
 
       /* Color account/folders font */
 

--- a/chrome/content/accountcolors-aboutmessage.js
+++ b/chrome/content/accountcolors-aboutmessage.js
@@ -146,28 +146,29 @@ var accountColorsAboutMessage = {
       return;
     }
 
-    /* Color based on received account */
-
-    if (accountColorsAboutMessage.prefs.getBoolPref("message-hdraccount")) {
-      /* color using account in message header */
-      accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
-      account = accountColorsAboutMessage.accountManager.getAccount(accountkey);
-
-      if (account == null) accountidkey = null; /* sent message */
-      else if (account.defaultIdentity == null) accountidkey = account.key;
-      else accountidkey = account.defaultIdentity.key;
-    } /* color using account in which folder is located */ else {
-      folder = msgHdr.folder;
-      server = folder.server;
-      account = accountColorsAboutMessage.accountManager.FindAccountForServer(server);
-
-      if (account.defaultIdentity == null) accountidkey = account.key;
-      else accountidkey = account.defaultIdentity.key;
-    }
-
-    // Use an empty id to cause color clearing.
     if (clear) {
-      accountidkey = "";
+      accountidkey = ""; // Use an empty id to cause color clearing.
+    } else if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAboutMessage.prefs.getBoolPref("message-hdraccount"));
+    } else {
+      /* Color based on received account */
+
+      if (accountColorsAboutMessage.prefs.getBoolPref("message-hdraccount")) {
+        /* color using account in message header */
+        accountkey = accountColorsUtilities.getAccountKey(msgHdr); /* null string if sent message */
+        account = accountColorsAboutMessage.accountManager.getAccount(accountkey);
+
+        if (account == null) accountidkey = null; /* sent message */
+        else if (account.defaultIdentity == null) accountidkey = account.key;
+        else accountidkey = account.defaultIdentity.key;
+      } /* color using account in which folder is located */ else {
+        folder = msgHdr.folder;
+        server = folder.server;
+        account = accountColorsAboutMessage.accountManager.FindAccountForServer(server);
+
+        if (account.defaultIdentity == null) accountidkey = account.key;
+        else accountidkey = account.defaultIdentity.key;
+      }
     }
 
     /* Color subject font */

--- a/chrome/content/accountcolors-aboutmessage.js
+++ b/chrome/content/accountcolors-aboutmessage.js
@@ -149,7 +149,7 @@ var accountColorsAboutMessage = {
     if (clear) {
       accountidkey = ""; // Use an empty id to cause color clearing.
     } else if (accountColorsUtilities.thunderbirdVersion.major >= 102) {
-      accountidkey = accountColorsUtilities.resolveAccountIdentityKey(msgHdr, accountColorsAboutMessage.prefs.getBoolPref("message-hdraccount"));
+      accountidkey = accountColorsUtilities.resolveAccountIdentityKeyForMessage(msgHdr, accountColorsAboutMessage.prefs.getBoolPref("message-hdraccount"));
     } else {
       /* Color based on received account */
 

--- a/chrome/content/accountcolors-aboutmessage.js
+++ b/chrome/content/accountcolors-aboutmessage.js
@@ -202,22 +202,37 @@ var accountColorsAboutMessage = {
       bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
       if (accountColorsAboutMessage.prefs.getBoolPref("message-defaultbkgd") && bkgdcolor == "#FFFFFF") bkgdcolor = "";
 
-      element = document.getElementById("expandedHeaderView"); // Removed since TB 102+
-      if (element != null) element.style.backgroundColor = bkgdcolor;
+      if (accountColorsAboutMessage.prefs.getBoolPref("message-colorbkgd-header-label")) {
+        element = document.getElementById("messageHeader");
+        if (element != null) {
+          width = accountColorsAboutMessage.prefs.getIntPref("message-header-label-width") + "px";
+          element.style.backgroundImage = "linear-gradient(to right, " + bkgdcolor + ", " + bkgdcolor + " " + width + ", transparent " + width + ", transparent 100%)";
+          element.style.backgroundColor = "";
+        }
+      } else {
+        element = document.getElementById("expandedHeaderView"); // Removed since TB 102+
+        if (element != null) element.style.backgroundColor = bkgdcolor;
 
-      element = document.getElementById("messageHeader");
-      if (element != null) element.style.backgroundColor = bkgdcolor;
+        element = document.getElementById("messageHeader");
+        if (element != null) {
+          element.style.backgroundColor = bkgdcolor;
+          element.style.backgroundImage = "";
+        }
 
-      /* For CompactHeader add-on */
+        /* For CompactHeader add-on */
 
-      element = document.getElementById("CompactHeader_collapsedHeaderView");
-      if (element != null) element.style.backgroundColor = bkgdcolor;
+        element = document.getElementById("CompactHeader_collapsedHeaderView");
+        if (element != null) element.style.backgroundColor = bkgdcolor;
+      }
     } else {
-      element = document.getElementById("expandedHeaderView");
+      element = document.getElementById("expandedHeaderView"); // Removed since TB 102+
       if (element != null) element.style.backgroundColor = "";
 
       element = document.getElementById("messageHeader");
-      if (element != null) element.style.backgroundColor = "";
+      if (element != null) {
+        element.style.backgroundColor = "";
+        element.style.backgroundImage = "";
+      }
 
       /* For CompactHeader add-on */
 

--- a/chrome/content/accountcolors-aboutmessage.js
+++ b/chrome/content/accountcolors-aboutmessage.js
@@ -205,12 +205,18 @@ var accountColorsAboutMessage = {
       element = document.getElementById("expandedHeaderView"); // Removed since TB 102+
       if (element != null) element.style.backgroundColor = bkgdcolor;
 
+      element = document.getElementById("messageHeader");
+      if (element != null) element.style.backgroundColor = bkgdcolor;
+
       /* For CompactHeader add-on */
 
       element = document.getElementById("CompactHeader_collapsedHeaderView");
       if (element != null) element.style.backgroundColor = bkgdcolor;
     } else {
       element = document.getElementById("expandedHeaderView");
+      if (element != null) element.style.backgroundColor = "";
+
+      element = document.getElementById("messageHeader");
       if (element != null) element.style.backgroundColor = "";
 
       /* For CompactHeader add-on */

--- a/chrome/content/accountcolors-composewindow.js
+++ b/chrome/content/accountcolors-composewindow.js
@@ -212,6 +212,7 @@ var accountColorsCompose = {
         if (menuitem.localName == "menuitem") {
           /* not menu separator */
           menuitem.style.backgroundColor = "";
+          menuitem.style.backgroundImage = "";
         }
       }
     }

--- a/chrome/content/accountcolors-composewindow.js
+++ b/chrome/content/accountcolors-composewindow.js
@@ -78,7 +78,7 @@ var accountColorsCompose = {
 
   composeWindow: function (event, clear = false) {
     var i, menulist, accountidkey, menupopup, menuitem;
-    var defaultbkgd, bkgdcolor, fontcolor, element, idkey, fontstyle, fontsize;
+    var defaultbkgd, bkgdcolor, fontcolor, element, idkey, fontstyle, fontsize, width;
 
     menulist = document.getElementById("msgIdentity");
 
@@ -167,7 +167,10 @@ var accountColorsCompose = {
     if (accountColorsCompose.prefs.getBoolPref("compose-colorfrombkgd")) {
       bkgdcolor = accountColorsUtilities.bkgdColorPref(accountidkey);
 
-      if (defaultbkgd) {
+      if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-idmenu-label")) { // Do not render background color of selected identity box in label mode
+        menulist = document.getElementById("msgIdentity");
+        menulist.style.backgroundColor = "";
+      } else if (defaultbkgd) {
         menulist = document.getElementById("msgIdentity");
         menulist.style.backgroundColor = "";
       } else {
@@ -183,8 +186,18 @@ var accountColorsCompose = {
         if (menuitem.localName == "menuitem") {
           /* not menu separator */
           idkey = menuitem.getAttribute("identitykey");
+          bkgdcolor = accountColorsUtilities.bkgdColorPref(idkey);
 
-          menuitem.style.backgroundColor = accountColorsUtilities.bkgdColorPref(idkey);
+          if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-idmenu-label")) {
+            width = accountColorsCompose.prefs.getIntPref("compose-idmenu-label-width") + "px";
+            menuitem.style.backgroundImage = "linear-gradient(to right, " + bkgdcolor + ", " + bkgdcolor + " " + width + ", transparent " + width + ", transparent 100%)";
+            menuitem.style.backgroundColor = "";
+            menuitem.style.setProperty("border-radius", "0", "");
+          } else {
+            menuitem.style.backgroundColor = bkgdcolor;
+            menuitem.style.backgroundImage = "";
+            menuitem.style.removeProperty("border-radius");
+          }
         }
       }
     } else {

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -443,6 +443,22 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    checkbox = document.getElementById("accountcolors-folder-colorbkgd-account-icon");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-account-icon");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
+    checkbox = document.getElementById("accountcolors-folder-colorbkgd-folder-icon");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-folder-icon");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
     /* Thread Pane Options */
 
     checkbox = document.getElementById("accountcolors-thread-setfontstyle");
@@ -1154,6 +1170,8 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("folder-darkerbar", document.getElementById("accountcolors-folder-darkerbar").checked);
     accountColorsOptions.prefs.setBoolPref("folder-incspacing", document.getElementById("accountcolors-folder-incspacing").checked);
     accountColorsOptions.prefs.setBoolPref("folder-hoverselect", document.getElementById("accountcolors-folder-hoverselect").checked);
+    accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-account-icon", document.getElementById("accountcolors-folder-colorbkgd-account-icon").checked);
+    accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-folder-icon", document.getElementById("accountcolors-folder-colorbkgd-folder-icon").checked);
 
     /* Thread Pane Options */
 

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -739,6 +739,14 @@ var accountColorsOptions = {
       menulist.selectedIndex = 1;
     }
 
+    checkbox = document.getElementById("accountcolors-thread-color-unified-only");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("thread-color-unified-only");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
     /* Message Pane, Message Tab & Message Window Options */
 
     checkbox = document.getElementById("accountcolors-message-setfontstyle");
@@ -1178,6 +1186,7 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-card-label", document.getElementById("accountcolors-thread-colorbkgd-card-label").checked);
     accountColorsOptions.prefs.setIntPref("thread-card-label-position", document.getElementById("accountcolors-thread-card-label-indent").value);
     accountColorsOptions.prefs.setIntPref("thread-card-label-width", document.getElementById("accountcolors-thread-card-label-width").value);
+    accountColorsOptions.prefs.setBoolPref("thread-color-unified-only", document.getElementById("accountcolors-thread-color-unified-only").checked);
 
     /* Message Pane, Message Tab & Message Window Options */
 

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -1126,6 +1126,35 @@ var accountColorsOptions = {
     } catch (e) {
       checkbox.checked = false;
     }
+
+    checkbox = document.getElementById("accountcolors-compose-colorbkgd-idmenu-label");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("compose-colorbkgd-idmenu-label");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
+    menulist = document.getElementById("accountcolors-compose-idmenu-label-width");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Width: 1", 1);
+    menulist.appendItem("Width: 2", 2);
+    menulist.appendItem("Width: 3", 3);
+    menulist.appendItem("Width: 4", 4);
+    menulist.appendItem("Width: 5", 5);
+    menulist.appendItem("Width: 6", 6);
+    menulist.appendItem("Width: 7", 7);
+    menulist.appendItem("Width: 8", 8);
+    menulist.appendItem("Width: 9", 9);
+    menulist.appendItem("Width: 10", 10);
+    menulist.appendItem("Width: 11", 11);
+    menulist.appendItem("Width: 12", 12);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("compose-idmenu-label-width");
+      menulist.selectedIndex = value - 1;
+    } catch (e) {
+      menulist.selectedIndex = 1;
+    }
   },
 
   /********************************************************************/
@@ -1251,6 +1280,7 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("compose-darkfieldbkgd", document.getElementById("accountcolors-compose-darkfieldbkgd").checked);
     // accountColorsOptions.prefs.setBoolPref("compose-defaultbkgd", document.getElementById("accountcolors-compose-defaultbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("compose-hoverfrom", document.getElementById("accountcolors-compose-hoverfrom").checked);
+    accountColorsOptions.prefs.setBoolPref("compose-colorbkgd-idmenu-label", document.getElementById("accountcolors-compose-colorbkgd-idmenu-label").checked);
   },
 
   /********************************************************************/

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -337,8 +337,12 @@ var accountColorsOptions = {
 
     checkbox = document.getElementById("accountcolors-folder-colorotherbkgd");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorotherbkgd");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorotherbkgd");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -453,16 +457,24 @@ var accountColorsOptions = {
 
     checkbox = document.getElementById("accountcolors-folder-colorbkgd-account-icon");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-account-icon");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-account-icon");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
 
     checkbox = document.getElementById("accountcolors-folder-colorbkgd-folder-icon");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-folder-icon");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-folder-icon");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -685,8 +697,12 @@ var accountColorsOptions = {
 
     checkbox = document.getElementById("accountcolors-thread-colorbkgd-row-label");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-row-label");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-row-label");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -696,8 +712,12 @@ var accountColorsOptions = {
     menulist.appendItem("Subject Column", 0);
     menulist.appendItem("First Column", 1);
     try {
-      value = accountColorsOptions.prefs.getIntPref("thread-row-label-position");
-      menulist.selectedIndex = value;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("thread-row-label-position");
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 0;
     }
@@ -717,16 +737,24 @@ var accountColorsOptions = {
     menulist.appendItem("Width: 11", 11);
     menulist.appendItem("Width: 12", 12);
     try {
-      value = accountColorsOptions.prefs.getIntPref("thread-row-label-width");
-      menulist.selectedIndex = value - 1;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("thread-row-label-width");
+        menulist.selectedIndex = value - 1;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 1;
     }
 
     checkbox = document.getElementById("accountcolors-thread-colorbkgd-card-label");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-card-label");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-card-label");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -736,8 +764,12 @@ var accountColorsOptions = {
     menulist.appendItem("No Indent", 0);
     menulist.appendItem("Indent", 1);
     try {
-      value = accountColorsOptions.prefs.getIntPref("thread-card-label-position");
-      menulist.selectedIndex = value;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("thread-card-label-position");
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 0;
     }
@@ -757,16 +789,24 @@ var accountColorsOptions = {
     menulist.appendItem("Width: 11", 11);
     menulist.appendItem("Width: 12", 12);
     try {
-      value = accountColorsOptions.prefs.getIntPref("thread-card-label-width");
-      menulist.selectedIndex = value - 1;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("thread-card-label-width");
+        menulist.selectedIndex = value - 1;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 1;
     }
 
     checkbox = document.getElementById("accountcolors-thread-color-unified-only");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("thread-color-unified-only");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("thread-color-unified-only");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -913,8 +953,12 @@ var accountColorsOptions = {
 
     checkbox = document.getElementById("accountcolors-message-colorbkgd-header-label");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("message-colorbkgd-header-label");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("message-colorbkgd-header-label");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -934,8 +978,12 @@ var accountColorsOptions = {
     menulist.appendItem("Width: 11", 11);
     menulist.appendItem("Width: 12", 12);
     try {
-      value = accountColorsOptions.prefs.getIntPref("message-header-label-width");
-      menulist.selectedIndex = value - 1;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("message-header-label-width");
+        menulist.selectedIndex = value - 1;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 1;
     }
@@ -1166,8 +1214,12 @@ var accountColorsOptions = {
 
     checkbox = document.getElementById("accountcolors-compose-colorbkgd-idmenu-label");
     try {
-      checkstate = accountColorsOptions.prefs.getBoolPref("compose-colorbkgd-idmenu-label");
-      checkbox.checked = checkstate;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        checkstate = accountColorsOptions.prefs.getBoolPref("compose-colorbkgd-idmenu-label");
+        checkbox.checked = checkstate;
+      } else {
+        checkbox.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       checkbox.checked = false;
     }
@@ -1187,8 +1239,12 @@ var accountColorsOptions = {
     menulist.appendItem("Width: 11", 11);
     menulist.appendItem("Width: 12", 12);
     try {
-      value = accountColorsOptions.prefs.getIntPref("compose-idmenu-label-width");
-      menulist.selectedIndex = value - 1;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getIntPref("compose-idmenu-label-width");
+        menulist.selectedIndex = value - 1;
+      } else {
+        menulist.style.display = "none"; // Hide option for thunderbird 102 and below, as not implemented for legacy mail frontend
+      }
     } catch (e) {
       menulist.selectedIndex = 1;
     }

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -903,6 +903,35 @@ var accountColorsOptions = {
     //   checkbox.checked = false;
     // }
 
+    checkbox = document.getElementById("accountcolors-message-colorbkgd-header-label");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("message-colorbkgd-header-label");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
+    menulist = document.getElementById("accountcolors-message-header-label-width");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Width: 1", 1);
+    menulist.appendItem("Width: 2", 2);
+    menulist.appendItem("Width: 3", 3);
+    menulist.appendItem("Width: 4", 4);
+    menulist.appendItem("Width: 5", 5);
+    menulist.appendItem("Width: 6", 6);
+    menulist.appendItem("Width: 7", 7);
+    menulist.appendItem("Width: 8", 8);
+    menulist.appendItem("Width: 9", 9);
+    menulist.appendItem("Width: 10", 10);
+    menulist.appendItem("Width: 11", 11);
+    menulist.appendItem("Width: 12", 12);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("message-header-label-width");
+      menulist.selectedIndex = value - 1;
+    } catch (e) {
+      menulist.selectedIndex = 1;
+    }
+
     /* Compose Window Options */
 
     checkbox = document.getElementById("accountcolors-compose-setfontstyle");
@@ -1252,6 +1281,8 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("message-whitehdrlabels", document.getElementById("accountcolors-message-whitehdrlabels").checked);
     // accountColorsOptions.prefs.setBoolPref("message-defaultbkgd", document.getElementById("accountcolors-message-defaultbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("message-hdraccount", document.getElementById("accountcolors-message-hdraccount").checked);
+    accountColorsOptions.prefs.setBoolPref("message-colorbkgd-header-label", document.getElementById("accountcolors-message-colorbkgd-header-label").checked);
+    accountColorsOptions.prefs.setIntPref("message-header-label-width", document.getElementById("accountcolors-message-header-label-width").value);
 
     /* Compose Window Options */
 

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -335,6 +335,14 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    checkbox = document.getElementById("accountcolors-folder-colorotherbkgd");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("folder-colorotherbkgd");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
     checkbox = document.getElementById("accountcolors-folder-blackrowfont");
     try {
       checkstate = accountColorsOptions.prefs.getBoolPref("folder-blackrowfont");
@@ -1216,6 +1224,7 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("folder-colorfldfont", document.getElementById("accountcolors-folder-colorfldfont").checked);
     accountColorsOptions.prefs.setBoolPref("folder-colorfldbkgd", document.getElementById("accountcolors-folder-colorfldbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("folder-colorother", document.getElementById("accountcolors-folder-colorother").checked);
+    accountColorsOptions.prefs.setBoolPref("folder-colorotherbkgd", document.getElementById("accountcolors-folder-colorotherbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("folder-blackrowfont", document.getElementById("accountcolors-folder-blackrowfont").checked);
     accountColorsOptions.prefs.setBoolPref("folder-lightpanebkgd", document.getElementById("accountcolors-folder-lightpanebkgd").checked);
     accountColorsOptions.prefs.setBoolPref("folder-whiterowfont", document.getElementById("accountcolors-folder-whiterowfont").checked);

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -73,7 +73,7 @@ var accountColorsOptions = {
 
   initPrefs: function () {
     var container, template, accountidbox, account, identity, index, acc, id;
-    var background, menulist, color, fontstyle, fontsize;
+    var background, menulist, color, fontstyle, fontsize, value;
     var checkbox, checkstate;
     var accounts = new Array();
     var identities = new Array();
@@ -659,6 +659,86 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    checkbox = document.getElementById("accountcolors-thread-colorbkgd-row-label");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-row-label");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
+    menulist = document.getElementById("accountcolors-thread-row-label-position");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Subject Column", 0);
+    menulist.appendItem("First Column", 1);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("thread-row-label-position");
+      menulist.selectedIndex = value;
+    } catch (e) {
+      menulist.selectedIndex = 0;
+    }
+
+    menulist = document.getElementById("accountcolors-thread-row-label-width");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Width: 1", 1);
+    menulist.appendItem("Width: 2", 2);
+    menulist.appendItem("Width: 3", 3);
+    menulist.appendItem("Width: 4", 4);
+    menulist.appendItem("Width: 5", 5);
+    menulist.appendItem("Width: 6", 6);
+    menulist.appendItem("Width: 7", 7);
+    menulist.appendItem("Width: 8", 8);
+    menulist.appendItem("Width: 9", 9);
+    menulist.appendItem("Width: 10", 10);
+    menulist.appendItem("Width: 11", 11);
+    menulist.appendItem("Width: 12", 12);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("thread-row-label-width");
+      menulist.selectedIndex = value - 1;
+    } catch (e) {
+      menulist.selectedIndex = 1;
+    }
+
+    checkbox = document.getElementById("accountcolors-thread-colorbkgd-card-label");
+    try {
+      checkstate = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-card-label");
+      checkbox.checked = checkstate;
+    } catch (e) {
+      checkbox.checked = false;
+    }
+
+    menulist = document.getElementById("accountcolors-thread-card-label-indent");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("No Indent", 0);
+    menulist.appendItem("Indent", 1);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("thread-card-label-position");
+      menulist.selectedIndex = value;
+    } catch (e) {
+      menulist.selectedIndex = 0;
+    }
+
+    menulist = document.getElementById("accountcolors-thread-card-label-width");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Width: 1", 1);
+    menulist.appendItem("Width: 2", 2);
+    menulist.appendItem("Width: 3", 3);
+    menulist.appendItem("Width: 4", 4);
+    menulist.appendItem("Width: 5", 5);
+    menulist.appendItem("Width: 6", 6);
+    menulist.appendItem("Width: 7", 7);
+    menulist.appendItem("Width: 8", 8);
+    menulist.appendItem("Width: 9", 9);
+    menulist.appendItem("Width: 10", 10);
+    menulist.appendItem("Width: 11", 11);
+    menulist.appendItem("Width: 12", 12);
+    try {
+      value = accountColorsOptions.prefs.getIntPref("thread-card-label-width");
+      menulist.selectedIndex = value - 1;
+    } catch (e) {
+      menulist.selectedIndex = 1;
+    }
+
     /* Message Pane, Message Tab & Message Window Options */
 
     checkbox = document.getElementById("accountcolors-message-setfontstyle");
@@ -1092,6 +1172,12 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("thread-darkerbar", document.getElementById("accountcolors-thread-darkerbar").checked);
     accountColorsOptions.prefs.setBoolPref("thread-incspacing", document.getElementById("accountcolors-thread-incspacing").checked);
     accountColorsOptions.prefs.setBoolPref("thread-hoverselect", document.getElementById("accountcolors-thread-hoverselect").checked);
+    accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-row-label", document.getElementById("accountcolors-thread-colorbkgd-row-label").checked);
+    accountColorsOptions.prefs.setIntPref("thread-row-label-position", document.getElementById("accountcolors-thread-row-label-position").value);
+    accountColorsOptions.prefs.setIntPref("thread-row-label-width", document.getElementById("accountcolors-thread-row-label-width").value);
+    accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-card-label", document.getElementById("accountcolors-thread-colorbkgd-card-label").checked);
+    accountColorsOptions.prefs.setIntPref("thread-card-label-position", document.getElementById("accountcolors-thread-card-label-indent").value);
+    accountColorsOptions.prefs.setIntPref("thread-card-label-width", document.getElementById("accountcolors-thread-card-label-width").value);
 
     /* Message Pane, Message Tab & Message Window Options */
 
@@ -1146,6 +1232,13 @@ var accountColorsOptions = {
 
   setMenuState: function (element) {
     document.getElementById(element.substr(0, element.lastIndexOf("-") + 1) + element.substr(element.lastIndexOf("-") + 4)).disabled = !document.getElementById(element).checked;
+  },
+
+  setMenuStateByCheckbox: function (checkbox, ...menulists) {
+    var menulist;
+    for (menulist of menulists) {
+      document.getElementById(menulist).disabled = !document.getElementById(checkbox).checked;
+    }
   },
 
   updateFontColor: function (index) {

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -1281,6 +1281,7 @@ var accountColorsOptions = {
     // accountColorsOptions.prefs.setBoolPref("compose-defaultbkgd", document.getElementById("accountcolors-compose-defaultbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("compose-hoverfrom", document.getElementById("accountcolors-compose-hoverfrom").checked);
     accountColorsOptions.prefs.setBoolPref("compose-colorbkgd-idmenu-label", document.getElementById("accountcolors-compose-colorbkgd-idmenu-label").checked);
+    accountColorsOptions.prefs.setIntPref("compose-idmenu-label-width", document.getElementById("accountcolors-compose-idmenu-label-width").value);
   },
 
   /********************************************************************/

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -258,6 +258,11 @@
         </hbox>
 
         <separator class="groove section" />
+
+        <hbox>
+          <checkbox id="accountcolors-message-colorbkgd-header-label" label="&accountcolors.message.colorbkgd.header.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-message-header-label-width');" />
+          <menulist id="accountcolors-message-header-label-width" />
+        </hbox>
       </tabpanel>
 
       <tabpanel id="accountcolors-compose-panel" orient="vertical">

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -122,6 +122,14 @@
         <hbox>
           <checkbox id="accountcolors-folder-hoverselect" label="&accountcolors.folder.hoverselect;" />
         </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-folder-colorbkgd-account-icon" label="&accountcolors.folder.colorbkgd.account.icon;" />
+        </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-folder-colorbkgd-folder-icon" label="&accountcolors.folder.colorbkgd.folder.icon;" />
+        </hbox>
       </tabpanel>
 
       <tabpanel id="accountcolors-thread-panel" orient="vertical">

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -187,6 +187,18 @@
         <hbox>
           <checkbox id="accountcolors-thread-hoverselect" label="&accountcolors.thread.hoverselect;" />
         </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-thread-colorbkgd-row-label" label="&accountcolors.thread.colorbkgd.row.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-thread-row-label-position', 'accountcolors-thread-row-label-width');" />
+          <menulist id="accountcolors-thread-row-label-position" />
+          <menulist id="accountcolors-thread-row-label-width" />
+        </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-thread-colorbkgd-card-label" label="&accountcolors.thread.colorbkgd.card.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-thread-card-label-indent', 'accountcolors-thread-card-label-width');" />
+          <menulist id="accountcolors-thread-card-label-indent" />
+          <menulist id="accountcolors-thread-card-label-width" />
+        </hbox>
       </tabpanel>
 
       <tabpanel id="accountcolors-message-panel" orient="vertical">

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -329,7 +329,7 @@
         </hbox>
 
         <hbox>
-          <checkbox id="accountcolors-compose-colorbkgd-idmenu-label" label="&accountcolors.thread.colorbkgd.idmenu.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-compose-idmenu-label-width');" />
+          <checkbox id="accountcolors-compose-colorbkgd-idmenu-label" label="&accountcolors.compose.colorbkgd.idmenu.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-compose-idmenu-label-width');" />
           <menulist id="accountcolors-compose-idmenu-label-width" />
         </hbox>
       </tabpanel>

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -81,6 +81,7 @@
 
         <hbox>
           <checkbox id="accountcolors-folder-colorother" label="&accountcolors.folder.colorother;" />
+          <checkbox id="accountcolors-folder-colorotherbkgd" label="&accountcolors.folder.colorotherbkgd;" />
         </hbox>
 
         <hbox>
@@ -156,9 +157,6 @@
 
         <hbox>
           <checkbox id="accountcolors-thread-colorfrom" label="&accountcolors.thread.colorfrom;" />
-        </hbox>
-
-        <hbox>
           <checkbox id="accountcolors-thread-colorother" label="&accountcolors.thread.colorother;" />
         </hbox>
 

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -199,6 +199,10 @@
           <menulist id="accountcolors-thread-card-label-indent" />
           <menulist id="accountcolors-thread-card-label-width" />
         </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-thread-color-unified-only" label="&accountcolors.thread.color.unified.only;" />
+        </hbox>
       </tabpanel>
 
       <tabpanel id="accountcolors-message-panel" orient="vertical">

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -327,6 +327,11 @@
         <hbox>
           <checkbox id="accountcolors-compose-hoverfrom" label="&accountcolors.compose.hoverfrom;" />
         </hbox>
+
+        <hbox>
+          <checkbox id="accountcolors-compose-colorbkgd-idmenu-label" label="&accountcolors.thread.colorbkgd.idmenu.label;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-compose-idmenu-label-width');" />
+          <menulist id="accountcolors-compose-idmenu-label-width" />
+        </hbox>
       </tabpanel>
     </tabpanels>
   </tabbox>

--- a/chrome/content/accountcolors-utilities.js
+++ b/chrome/content/accountcolors-utilities.js
@@ -73,7 +73,7 @@ var accountColorsUtilities = {
 
   /* Resolve account / identity key for message, for thunderbird 102+ */
 
-  resolveAccountIdentityKey: function (msgHdr, searchAllAccounts) {
+  resolveAccountIdentityKeyForMessage: function (msgHdr, searchAllAccounts) {
     var msgFolder, msgServer, msgAccount;
     var account, identity, address;
     var identities, matches, header, ccList;
@@ -152,6 +152,47 @@ var accountColorsUtilities = {
     }
 
     return msgAccount.key;
+  },
+
+  /* Resolve account / identity key for folder, for thunderbird 102+ */
+
+  resolveAccountIdentityKeyForFolder: function (folder) {
+    var server = folder.server;
+    var account = accountColorsAbout3Pane.accountManager.FindAccountForServer(server);
+    var identities = account.identities || [];
+    var identity, currentFolder;
+
+    /* If folder name or any of its parent folder's name matches identity's email, use this identity */
+
+    for (identity of identities) {
+      currentFolder = folder;
+      while (!!currentFolder.parent) { // Do not check root folder, as it's always default identity's email
+        if (currentFolder.abbreviatedName.toLowerCase() == identity.email.toLowerCase()) {
+          return identity.key;
+        }
+        currentFolder = currentFolder.parent;
+      }
+    }
+
+    /* If folder name or any of its parent folder's name matches identity's name, use this identity */
+
+    for (identity of identities) {
+      currentFolder = folder;
+      while (!!currentFolder.parent) {
+        if (currentFolder.abbreviatedName.toLowerCase() == identity.fullName.toLowerCase()) {
+          return identity.key;
+        }
+        currentFolder = currentFolder.parent;
+      }
+    }
+
+    /* Fallback to use default identity or account key */
+
+    if (!!account.defaultIdentity) {
+      return account.defaultIdentity.key;
+    }
+
+    return account.key;
   },
 
   /* Find account key for message recipient */

--- a/chrome/content/accountcolors-utilities.js
+++ b/chrome/content/accountcolors-utilities.js
@@ -33,7 +33,8 @@ var accountColorsUtilities = {
 
   accountManager: Components.classes["@mozilla.org/messenger/account-manager;1"].getService(Components.interfaces.nsIMsgAccountManager),
 
-  headerParser: Components.classes["@mozilla.org/messenger/headerparser;1"].getService(Components.interfaces.nsIMsgHeaderParser),
+  headerParser: Components.classes["@mozilla.org/messenger/headerparser;1"].getService(Components.interfaces.nsIMsgHeaderParser).wrappedJSObject ||
+                Components.classes["@mozilla.org/messenger/headerparser;1"].getService(Components.interfaces.nsIMsgHeaderParser),
 
   debugCount: 0,
 
@@ -68,6 +69,89 @@ var accountColorsUtilities = {
     }
 
     return accountkey;
+  },
+
+  /* Resolve account / identity key for message, for thunderbird 102+ */
+
+  resolveAccountIdentityKey: function (msgHdr, searchAllAccounts) {
+    var msgFolder, msgServer, msgAccount;
+    var account, identity, address;
+    var identities, matches, header, ccList;
+    var identityMap = new Map();
+
+    if (msgHdr.accountKey != "") {
+      return msgHdr.accountKey;
+    }
+
+    msgFolder = msgHdr.folder;
+    msgServer = msgFolder.server;
+    msgAccount = accountColorsUtilities.accountManager.FindAccountForServer(msgServer);
+
+    /* If searchAllAccounts = false, the result account / identity will only come from message's folder account */
+
+    for (account of searchAllAccounts ? accountColorsUtilities.accountManager.accounts : [msgAccount]) {
+      for (identity of account.identities || []) {
+        identities = identityMap.get(identity.email);
+        if (!identities) {
+          identities = []
+          identityMap.set(identity.email, identities);
+        }
+        if (account.incomingServer.type == msgServer.type) {
+          identities.unshift(identity); // Prefer identity that has same server type as message
+        } else {
+          identities.push(identity);
+        }
+      }
+    }
+
+    /* Search Recipient list first */
+
+    for (address of accountColorsUtilities.headerParser.parseDecodedHeader(msgHdr.mime2DecodedRecipients)) {
+      identities = identityMap.get(address.email);
+      if (identities && identities.length > 0) {
+        return identities[0].key; // Use first identity (as it is preferred)
+      }
+    }
+
+    /* Search `Received` header's `for <email>` fields next, as Recipient's address may be special group address (e.g. GitHub notifications) */
+
+    header = msgHdr.getStringProperty("received");
+    if (header) {
+      matches = header.match(/for\s+<([^>]+)>/);
+      identities = matches && identityMap.get(matches[1]);
+      if (identities && identities.length > 0) {
+        return identities[0].key;
+      }
+    }
+
+    /* Search for CC and BCC list next */
+
+    ccList = msgHdr.ccList && msgHdr.bccList ? `${msgHdr.ccList}, ${msgHdr.bccList}` : msgHdr.ccList || msgHdr.bccList;
+    if (ccList) {
+      for (address of accountColorsUtilities.headerParser.parseDecodedHeader(ccList)) {
+        identities = identityMap.get(address.email);
+        if (identities && identities.length > 0) {
+          return identities[0].key;
+        }
+      }
+    }
+
+    /* Search for Author (Message could be a sent message) */
+
+    for (address of accountColorsUtilities.headerParser.parseDecodedHeader(msgHdr.mime2DecodedAuthor)) {
+      identities = identityMap.get(address.email);
+      if (identities && identities.length > 0) {
+        return identities[0].key;
+      }
+    }
+
+    /* Default fallback */
+
+    if (msgAccount.defaultIdentity) {
+      return msgAccount.defaultIdentity.key;
+    }
+
+    return msgAccount.key;
   },
 
   /* Find account key for message recipient */

--- a/chrome/locale/de/accountcolors.dtd
+++ b/chrome/locale/de/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Ordnertext kolorieren">
 <!ENTITY accountcolors.folder.colorfldbkgd "Ordner-Hintergrund kolorieren">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Dunklere Auswahlleiste">
 <!ENTITY accountcolors.folder.incspacing "Zeilenabstand an die Schriftgröße der Konten-Bezeichnung anpassen">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Betreffzeilen-Schriftstil:">
 <!ENTITY accountcolors.thread.setfontsize "Betreffzeilen-Schriftgröße:">
 <!ENTITY accountcolors.thread.setfromstyle "Von-Zeilen-Schriftstil:">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Dunklere Farben für nicht-fokussierte Auswahlleiste">
 <!ENTITY accountcolors.thread.incspacing "Zeilenabstand an die Schriftgröße der Betreffzeile anpassen">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Betreffzeilen-Schriftstil:">
 <!ENTITY accountcolors.message.setfontsize "Betreffzeilen-Schriftgröße:">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels   "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Farben je nach Empfängerkonto anders">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Betreffzeilen-Schriftstil:">
 <!ENTITY accountcolors.compose.setfontsize "Betreffzeilen-Schriftgröße:">
 <!ENTITY accountcolors.compose.setidfontstyle "Von-Zeilen-Schriftstil:">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Farbauswahl-Text">
 <!ENTITY accountcolors.picker.bkgdtitle "Farbauswahl-Hintergrund">
 <!ENTITY accountcolors.picker.sample "Vorschau">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -37,6 +37,8 @@
 <!ENTITY accountcolors.folder.darkerbar         "Darker Unfocused Select Bar">
 <!ENTITY accountcolors.folder.incspacing        "Increase Row Spacing based on Account Font Size (even if Account Font Size not ticked)">
 <!ENTITY accountcolors.folder.hoverselect       "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
 <!ENTITY accountcolors.thread.setfontstyle      "Subject Font Style">
 <!ENTITY accountcolors.thread.setfontsize       "Subject Font Size">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -53,7 +53,7 @@
 <!ENTITY accountcolors.thread.lightpanebkgd     "Light Pane Background">
 <!ENTITY accountcolors.thread.whiterowfont      "White Row Fonts">
 <!ENTITY accountcolors.thread.darkpanebkgd      "Dark Pane Background">
-<!ENTITY accountcolors.thread.hdraccount        "Color based on Received Account (instead of Folder Account)">
+<!ENTITY accountcolors.thread.hdraccount        "Color based on Account of Received Email&apos;s Address (instead of Folder&apos;s Account)">
 <!ENTITY accountcolors.thread.boldsubject       "Bold Subject on Unread Messages">
 <!ENTITY accountcolors.thread.boldfrom          "Bold From on Unread Messages">
 <!ENTITY accountcolors.thread.hidestripes       "Hide Row Stripes">
@@ -74,7 +74,7 @@
 <!ENTITY accountcolors.message.colorfrom        "Color From Font">
 <!ENTITY accountcolors.message.blackhdrlabels   "Black Header Labels">
 <!ENTITY accountcolors.message.whitehdrlabels   "White Header Labels">
-<!ENTITY accountcolors.message.hdraccount       "Color based on Received Account (instead of Folder Account)">
+<!ENTITY accountcolors.message.hdraccount       "Color based on Account of Received Email&apos;s Address (instead of Folder&apos;s Account)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -75,6 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels   "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount       "Color based on Received Account (instead of Folder Account)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle     "Subject Font Style">
 <!ENTITY accountcolors.compose.setfontsize      "Subject Font Size">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -60,6 +60,7 @@
 <!ENTITY accountcolors.thread.hoverselect       "Reinstate default hover and select styles">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
 
 <!ENTITY accountcolors.message.setfontstyle     "Subject Font Style">
 <!ENTITY accountcolors.message.setfontsize      "Subject Font Size">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -58,6 +58,8 @@
 <!ENTITY accountcolors.thread.darkerbar         "Darker Unfocused Select Bar">
 <!ENTITY accountcolors.thread.incspacing        "Increase Row Spacing based on Subject/From Font Sizes (even if Subject/From Font Sizes not ticked)">
 <!ENTITY accountcolors.thread.hoverselect       "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 
 <!ENTITY accountcolors.message.setfontstyle     "Subject Font Style">
 <!ENTITY accountcolors.message.setfontsize      "Subject Font Size">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -25,6 +25,7 @@
 <!ENTITY accountcolors.folder.colorfldfont      "Color Folder Font">
 <!ENTITY accountcolors.folder.colorfldbkgd      "Color Folder Background">
 <!ENTITY accountcolors.folder.colorother        "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total/Size Background">
 <!ENTITY accountcolors.folder.blackrowfont      "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd     "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont      "White Row Fonts">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -97,6 +97,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd    "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom        "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.thread.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle         "Font Color Picker">
 <!ENTITY accountcolors.picker.bkgdtitle         "Background Color Picker">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -25,7 +25,7 @@
 <!ENTITY accountcolors.folder.colorfldfont      "Color Folder Font">
 <!ENTITY accountcolors.folder.colorfldbkgd      "Color Folder Background">
 <!ENTITY accountcolors.folder.colorother        "Color Unread/Total/Size Fonts">
-<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total/Size Background">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont      "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd     "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont      "White Row Fonts">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -97,7 +97,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd    "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom        "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.thread.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle         "Font Color Picker">
 <!ENTITY accountcolors.picker.bkgdtitle         "Background Color Picker">

--- a/chrome/locale/es-ES/accountcolors.dtd
+++ b/chrome/locale/es-ES/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Color de Fuente de Carpeta">
 <!ENTITY accountcolors.folder.colorfldbkgd "Color de Fondo de Carpeta">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Barra de Selección mas Oscura">
 <!ENTITY accountcolors.folder.incspacing "Incrementar espaciado de líneas en el tamaño de fuente de la cuenta (incluso si el tamaño de la cuenta no se ha marcado)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Estilo de Fuente del Asunto">
 <!ENTITY accountcolors.thread.setfontsize "Tamaño de Fuente del Asunto">
 <!ENTITY accountcolors.thread.setfromstyle "Estilo de fuente del formulario">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Barra Seleccionada mas Oscura">
 <!ENTITY accountcolors.thread.incspacing "Incrementar espaciado de líneas en el tamaño de la fuente del remitente (incluso si el tamaño de la fuente del remitente no se ha marcado)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Estilo de Fuente de Asunto">
 <!ENTITY accountcolors.message.setfontsize "Tamaño de Fuente de Asunto">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Color basado en la cabecera de cuenta de mensaje (en lugar de carpeta de la cuenta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Estilo de fuente del Asunto">
 <!ENTITY accountcolors.compose.setfontsize "Tamaño de Fuente del Asunto">
 <!ENTITY accountcolors.compose.setidfontstyle "Estilo de Fuente de Remitente">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Selector de color de fuente">
 <!ENTITY accountcolors.picker.bkgdtitle "Selector de color de fondo">
 <!ENTITY accountcolors.picker.sample "Ejemplo">

--- a/chrome/locale/fi-FI/accountcolors.dtd
+++ b/chrome/locale/fi-FI/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Väritä kansion fontti">
 <!ENTITY accountcolors.folder.colorfldbkgd "Väritä kansion tausta">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.folder.incspacing "Lisää riviväliä riippuen tilin fontin koosta (vaikka tilin fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.thread.setfontsize "Aiheen fonttikokok">
 <!ENTITY accountcolors.thread.setfromstyle "Vastausosoitteen fonttityyli">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.thread.incspacing "Lisää riviväliä riippuen aiheen fonttikoosta (vaikka aiheen fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.message.setfontsize "Aiheen fonttikoko">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Väritys riippuu viestiin liittyvän tilin värityksestä (kansion värityksen sijasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.compose.setfontsize "Aiheen fonttikoko">
 <!ENTITY accountcolors.compose.setidfontstyle "Identiteetin fonttityyli">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Fonttivärin valitsin">
 <!ENTITY accountcolors.picker.bkgdtitle "Taustavärin valitsin">
 <!ENTITY accountcolors.picker.sample "Esimerkki">

--- a/chrome/locale/fi/accountcolors.dtd
+++ b/chrome/locale/fi/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Väritä kansion fontti">
 <!ENTITY accountcolors.folder.colorfldbkgd "Väritä kansion tausta">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.folder.incspacing "Lisää riviväliä riippuen tilin fontin koosta (vaikka tilin fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.thread.setfontsize "Aiheen fonttikokok">
 <!ENTITY accountcolors.thread.setfromstyle "Vastausosoitteen fonttityyli">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.thread.incspacing "Lisää riviväliä riippuen aiheen fonttikoosta (vaikka aiheen fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.message.setfontsize "Aiheen fonttikoko">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Väritys riippuu viestiin liittyvän tilin värityksestä (kansion värityksen sijasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Aiheen fonttityyli">
 <!ENTITY accountcolors.compose.setfontsize "Aiheen fonttikoko">
 <!ENTITY accountcolors.compose.setidfontstyle "Identiteetin fonttityyli">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Fonttivärin valitsin">
 <!ENTITY accountcolors.picker.bkgdtitle "Taustavärin valitsin">
 <!ENTITY accountcolors.picker.sample "Esimerkki">

--- a/chrome/locale/fr/accountcolors.dtd
+++ b/chrome/locale/fr/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Couleur de la police des dossier">
 <!ENTITY accountcolors.folder.colorfldbkgd "Couleur de fond des dossier">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Barre de sélection plus sombre">
 <!ENTITY accountcolors.folder.incspacing "Augmenter l'espacement entre les lignes en fonction de la taille de la police des comptes (même si cette taille n'est pas sélectionnée)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Style de la police du sujet">
 <!ENTITY accountcolors.thread.setfontsize "Taille de la police du sujet">
 <!ENTITY accountcolors.thread.setfromstyle "Style de la police du champ expéditeur">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Barre de sélection plus sombre">
 <!ENTITY accountcolors.thread.incspacing "Augmenter l'espacement entre les lignes en fonction de la taille de la police du sujet (même si cette taille n'est pas sélectionnée)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Style de la police du sujet">
 <!ENTITY accountcolors.message.setfontsize "Taille de la police du sujet">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Couleur basée sur l'en-tête du message et non le dossier du compte">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Style de la police du sujet">
 <!ENTITY accountcolors.compose.setfontsize "Taille de la police du sujet">
 <!ENTITY accountcolors.compose.setidfontstyle "Style de la police de l'identité">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Palette de couleurs de la police">
 <!ENTITY accountcolors.picker.bkgdtitle "Palette de couleurs du fond">
 <!ENTITY accountcolors.picker.sample "Exemple">

--- a/chrome/locale/it/accountcolors.dtd
+++ b/chrome/locale/it/accountcolors.dtd
@@ -21,6 +21,7 @@
 <!ENTITY accountcolors.folder.colorfldbkgd "Colora sfondo Cartella">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
 <!ENTITY accountcolors.folder.darkpanebkgd "Dark Pane Background">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Barra di selezione più scura">
 <!ENTITY accountcolors.folder.incspacing "Aumenta spaziatura righe in base alla dimensione font Account (anche se dimensione font Account non è selezionata)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Stile font Oggetto">
 <!ENTITY accountcolors.thread.setfontsize "Dimensioni font Oggetto">
 <!ENTITY accountcolors.thread.setfromstyle "Stile font Da">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Barra di selezione più scura">
 <!ENTITY accountcolors.thread.incspacing "Aumenta spaziatura righe in base alla dimensione font Oggetto (anche se dimensione font Oggetto non è selezionata)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Stile font Oggetto">
 <!ENTITY accountcolors.message.setfontsize "Dimensioni font Oggetto">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Colore in base all'Account nell'header del messaggio (invece dell'Account della cartella)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Style font Oggetto">
 <!ENTITY accountcolors.compose.setfontsize "Dimensioni font Oggetto">
 <!ENTITY accountcolors.compose.setidfontstyle "Stile font Identità">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Selettore colore font">
 <!ENTITY accountcolors.picker.bkgdtitle "Selettore colore sfondo">
 <!ENTITY accountcolors.picker.sample "Esempio">

--- a/chrome/locale/pt-BR/accountcolors.dtd
+++ b/chrome/locale/pt-BR/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Cor da Fonte das Pasta">
 <!ENTITY accountcolors.folder.colorfldbkgd "Cor de Fundo das Pasta">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Escurecer Barra da Seleção">
 <!ENTITY accountcolors.folder.incspacing "Aumentar espaço entre linhas baseado no tamanho da fonte das contas (mesmo se este não estiver personalizado)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Estilo da fonte do assunto">
 <!ENTITY accountcolors.thread.setfontsize "Tamanho da fonte do assunto">
 <!ENTITY accountcolors.thread.setfromstyle "Estilo da fonte do remetente">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Escurecer barra da seleção">
 <!ENTITY accountcolors.thread.incspacing "Aumentar espaço entre linhas baseado no tamanho da fonte do assunto (mesmo se esta não for personalizada)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Estilo da fonte do assunto">
 <!ENTITY accountcolors.message.setfontsize "Tamanho da fonte do assunto">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Cor baseada na conta do cabeçalho da mensagem (ao invés da conta da pasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Estilo da fonte do assunto">
 <!ENTITY accountcolors.compose.setfontsize "Tamanho da fonte do assunto">
 <!ENTITY accountcolors.compose.setidfontstyle "Estilo da fonte do perfil">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Escolher cor da fonte">
 <!ENTITY accountcolors.picker.bkgdtitle "Escolher cor do fundo">
 <!ENTITY accountcolors.picker.sample "Amostra">

--- a/chrome/locale/sv-SE/accountcolors.dtd
+++ b/chrome/locale/sv-SE/accountcolors.dtd
@@ -20,6 +20,7 @@
 <!ENTITY accountcolors.folder.colorfldfont "Färga mapp typsnitt">
 <!ENTITY accountcolors.folder.colorfldbkgd "Färga mapp bakgrund">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
@@ -32,6 +33,9 @@
 <!ENTITY accountcolors.folder.darkerbar "Mörkare färgning av markerat fält">
 <!ENTITY accountcolors.folder.incspacing "Öka radavståndet baserat på teckenstorleken för konton (även om &quot;Teckenstorlek för konto&quot; inte är markerat)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "Teckenstil för ämnesrad">
 <!ENTITY accountcolors.thread.setfontsize "Teckenstorlek för ämnesrad">
 <!ENTITY accountcolors.thread.setfromstyle "From Font Style">
@@ -52,6 +56,10 @@
 <!ENTITY accountcolors.thread.darkerbar "Mörkare färgning av markerat fält">
 <!ENTITY accountcolors.thread.incspacing "Öka radavståndet baserat på teckenstorleken för ämnesrader (även om &quot;Teckenstorlek för ämnesrad&quot; inte är markerat)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
+
 <!ENTITY accountcolors.message.setfontstyle "Teckenstil för ämnesrad">
 <!ENTITY accountcolors.message.setfontsize "Teckenstorlek för ämnesrad">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +71,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Färga baserat på meddelandehuvudets konto (istället för mappens konto)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "Teckenstil för ämnesrad">
 <!ENTITY accountcolors.compose.setfontsize "Teckenstorlek för ämnesrad">
 <!ENTITY accountcolors.compose.setidfontstyle "Teckenstil för identitet">
@@ -84,6 +94,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "Font Color Picker">
 <!ENTITY accountcolors.picker.bkgdtitle "Background Color Picker">
 <!ENTITY accountcolors.picker.sample "Sample">

--- a/chrome/locale/zh-CN/accountcolors.dtd
+++ b/chrome/locale/zh-CN/accountcolors.dtd
@@ -20,18 +20,22 @@
 <!ENTITY accountcolors.folder.colorfldfont "文件夹字体颜色">
 <!ENTITY accountcolors.folder.colorfldbkgd "文件夹背景色">
 <!ENTITY accountcolors.folder.colorother "Color Unread/Total/Size Fonts">
+<!ENTITY accountcolors.folder.colorotherbkgd    "Color Unread/Total Background">
 <!ENTITY accountcolors.folder.blackrowfont "Black Row Fonts">
 <!ENTITY accountcolors.folder.lightpanebkgd "Light Pane Background">
 <!ENTITY accountcolors.folder.whiterowfont "White Row Fonts">
 <!ENTITY accountcolors.folder.darkpanebkgd "Dark Pane Background">
 <!ENTITY accountcolors.folder.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.folder.boldnewmail "粗体显示有新邮件的帐户/文件夹">
-<!ENTITY accountcolors.folder.undernewmail "斜体显示有新邮件的帐户/文件夹">
+<!ENTITY accountcolors.folder.undernewmail "下划线显示有新邮件的帐户/文件夹">
 <!ENTITY accountcolors.folder.noboldunread "文件夹有未读消息时不要显示为粗体">
 <!ENTITY accountcolors.folder.showlines "显示树状连线">
 <!ENTITY accountcolors.folder.darkerbar "暗色选择栏">
 <!ENTITY accountcolors.folder.incspacing "基于帐户字体大小增加行间距（即使帐户字体大小未勾选）">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
+<!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
+
 <!ENTITY accountcolors.thread.setfontstyle "话题字体样式">
 <!ENTITY accountcolors.thread.setfontsize "话题字体样式">
 <!ENTITY accountcolors.thread.setfromstyle "来自字体样式">
@@ -52,6 +56,9 @@
 <!ENTITY accountcolors.thread.darkerbar "暗色选择栏">
 <!ENTITY accountcolors.thread.incspacing "基于话题字体大小增加行间距（即使话题字体大小未勾选）">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
+<!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
+<!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
+<!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
 <!ENTITY accountcolors.message.setfontstyle "话题字体样式">
 <!ENTITY accountcolors.message.setfontsize "话题字体大小">
 <!ENTITY accountcolors.message.setfromstyle "From Font Style">
@@ -63,6 +70,8 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "基于消息标头帐户的颜色（文件夹帐户的替代）">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
+<!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
+
 <!ENTITY accountcolors.compose.setfontstyle "话题字体样式">
 <!ENTITY accountcolors.compose.setfontsize "话题字体大小">
 <!ENTITY accountcolors.compose.setidfontstyle "身份字体样式">
@@ -84,6 +93,8 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
+<!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
+
 <!ENTITY accountcolors.picker.fonttitle "字体颜色选择器">
 <!ENTITY accountcolors.picker.bkgdtitle "背景颜色选择器">
 <!ENTITY accountcolors.picker.sample "样例">

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -25,7 +25,7 @@
 
 /**********************************************************************************************************************/
 
-/* Folder Pane - Font Colors / Background Colors */
+/* Folder Pane - Font Colors / Background Colors / Font Style / Font Weight */
 
 /* Reinstate default font and background colors for selected and hover rows */
 
@@ -37,6 +37,20 @@
 #folderTree:focus-within li.selected > .container > *, #folderTree li.drop-target > .container > * {
     background-color: inherit !important;
     color: inherit !important;
+}
+
+#folderTree li[is="folder-tree-row"] .name {
+    color: var(--ac-font-color);
+    font-style: var(--ac-font-style);
+    font-weight: var(--ac-font-weight);
+}
+
+#folderTree li[is="folder-tree-row"] .container {
+    background-color: var(--ac-bkgd-color);
+}
+
+#folderTree li[is="folder-tree-row"] :is(.unread-count, .total-count, .folder-size) {
+    color: var(--ac-font-color, var(--folderpane-unread-count-text));
 }
 
 /**********************************************************************************************************************/

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -25,7 +25,7 @@
 
 /**********************************************************************************************************************/
 
-/* Folder Pane - Font Colors / Background Colors / Font Style / Font Weight */
+/* Folder Pane - Font Colors / Background Colors */
 
 /* Reinstate default font and background colors for selected and hover rows */
 
@@ -41,8 +41,6 @@
 
 #folderTree li[is="folder-tree-row"] .name {
     color: var(--ac-font-color);
-    font-style: var(--ac-font-style);
-    font-weight: var(--ac-font-weight);
 }
 
 #folderTree li[is="folder-tree-row"] .container {
@@ -60,6 +58,13 @@
 #folderTree li[is="folder-tree-row"] .new-messages > .container > :is(.unread-count, .total-count, .folder-size) {
     background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-new-count-background));
 }
+
+/* Folder Pane - Font Style / Font Weight */
+
+#folderTree li[is="folder-tree-row"][ac-fsw="normal"] { font-style: normal; font-weight:normal; }
+#folderTree li[is="folder-tree-row"][ac-fsw="italic"] { font-style: italic; font-weight:normal; }
+#folderTree li[is="folder-tree-row"][ac-fsw="bold"] { font-style: normal; font-weight:bold; }
+#folderTree li[is="folder-tree-row"][ac-fsw="bolditalic"] { font-style: italic; font-weight:bold; }
 
 /**********************************************************************************************************************/
 
@@ -143,7 +148,7 @@
 
 /**********************************************************************************************************************/
 
-/* Thread Pane - Font Colors / Background Colors / Font Style / Font Weight */
+/* Thread Pane - Font Colors / Background Colors */
 
 /* Reinstate default font and background colors for selected and hover rows */
 
@@ -163,8 +168,6 @@
 
 #threadTree tr[is="thread-row"] > td, #threadTree tr[is="thread-card"] :is(.subject, .sender, .date) {
     color: var(--ac-font-color);
-    font-style: var(--ac-font-style);
-    font-weight: var(--ac-font-weight);
 }
 
 #threadTree:not([ac-bkgdaslabel-row]) tr[is="thread-row"] {
@@ -195,6 +198,18 @@
 #threadTree[ac-bkgdaslabel-card="indent"] tr[is="thread-card"] .thread-card-container {
     background-image: linear-gradient(to right, var(--ac-bkgd-color), var(--ac-bkgd-color) var(--ac-card-label-width), transparent var(--ac-card-label-width), transparent 100%);
 }
+
+/* Thread Pane - Font Style / Font Weight */
+
+#threadTree tr[is="thread-row"] > td[ac-fsw="normal"] { font-style: normal; font-weight:normal; }
+#threadTree tr[is="thread-row"] > td[ac-fsw="italic"] { font-style: italic; font-weight:normal; }
+#threadTree tr[is="thread-row"] > td[ac-fsw="bold"] { font-style: normal; font-weight:bold; }
+#threadTree tr[is="thread-row"] > td[ac-fsw="bolditalic"] { font-style: italic; font-weight:bold; }
+
+#threadTree tr[is="thread-card"] :is(.subject, .sender, .date)[ac-fsw="normal"] { font-style: normal; font-weight:normal; }
+#threadTree tr[is="thread-card"] :is(.subject, .sender, .date)[ac-fsw="italic"] { font-style: italic; font-weight:normal; }
+#threadTree tr[is="thread-card"] :is(.subject, .sender, .date)[ac-fsw="bold"] { font-style: normal; font-weight:bold; }
+#threadTree tr[is="thread-card"] :is(.subject, .sender, .date)[ac-fsw="bolditalic"] { font-style: italic; font-weight:bold; }
 
 /**********************************************************************************************************************/
 

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -39,24 +39,34 @@
     color: inherit !important;
 }
 
+#folderTree li.selected > .container {
+    background-color: var(--treeitem-background-selected) !important;
+}
+
 #folderTree li[is="folder-tree-row"] .name {
-    color: var(--ac-font-color);
+    color: var(--ac-font-color, currentColor);
+}
+
+#folderTree li[is="folder-tree-row"] .new-messages > .container > .name {
+    color: var(--ac-font-color, var(--new-folder-color));
 }
 
 #folderTree li[is="folder-tree-row"] .container {
     background-color: var(--ac-bkgd-color);
 }
 
-#folderTree li[is="folder-tree-row"] :is(.unread-count, .total-count, .folder-size) {
+#folderTree li[is="folder-tree-row"] .unread:not(.new-messages) > .container > .unread-count {
     color: var(--ac-font-color, var(--folderpane-unread-count-text));
-}
-
-#folderTree li[is="folder-tree-row"] .unread > .container > :is(.unread-count, .total-count, .folder-size) {
     background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-count-background));
 }
 
-#folderTree li[is="folder-tree-row"] .new-messages > .container > :is(.unread-count, .total-count, .folder-size) {
-    background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-new-count-background));
+#folderTree li[is="folder-tree-row"] .total-count {
+    color: var(--ac-font-color, var(--folderpane-total-count-text));
+    background-color: var(--ac-badge-bkgd-color, var(--folderpane-total-count-background));
+}
+
+#folderTree li[is="folder-tree-row"] .folder-size {
+    color: var(--ac-font-color, var(--layout-color-3));
 }
 
 /* Folder Pane - Font Style / Font Weight */
@@ -162,12 +172,15 @@
 [is="tree-view-table-body"]:focus tr.selected *,
 [is="tree-view-table-body"]:focus-within tr.selected *,
 [is="tree-view-table-body"] tr.selected:focus-within * {
-    background-color: inherit !important;
     color: inherit !important;
 }
 
-#threadTree tr[is="thread-row"] > td, #threadTree tr[is="thread-card"] :is(.subject, .sender, .date) {
-    color: var(--ac-font-color);
+#threadTree tr[is="thread-row"] > td, #threadTree tr[is="thread-card"] .subject {
+    color: var(--tag-color, var(--ac-font-color, currentColor));
+}
+
+#threadTree tr[is="thread-card"] :is(.sender, .date) {
+    color: var(--ac-font-color, currentColor);
 }
 
 #threadTree:not([ac-bkgdaslabel-row]) tr[is="thread-row"] {
@@ -314,9 +327,7 @@
 /* Ensure bold font on subject / from columns even their styles are set to normal/italic */
 
 #threadTree:not([ac-boldsubjectfrom]) tbody > tr[data-properties~="unread"][is="thread-row"] > td,
-#threadTree:not([ac-boldsubjectfrom]) tbody > tr[data-properties~="unread"][is="thread-card"] .subject,
-#threadTree:not([ac-boldsubjectfrom]) tbody > tr[data-properties~="unread"][is="thread-card"] .sender,
-#threadTree:not([ac-boldsubjectfrom]) tbody > tr[data-properties~="unread"][is="thread-card"] .date {
+#threadTree:not([ac-boldsubjectfrom]) tbody > tr[data-properties~="unread"][is="thread-card"] :is(.subject, .sender, .date) {
     font-weight: bold !important;
 }
 
@@ -325,9 +336,7 @@
 /* If either Bold Subject or Bold From set, all columns are unbold by default  */
 
 #threadTree[ac-boldsubjectfrom] tbody > tr[data-properties~="unread"][is="thread-row"] > td,
-#threadTree[ac-boldsubjectfrom] tbody > tr[data-properties~="unread"][is="thread-card"] .subject,
-#threadTree[ac-boldsubjectfrom] tbody > tr[data-properties~="unread"][is="thread-card"] .sender,
-#threadTree[ac-boldsubjectfrom] tbody > tr[data-properties~="unread"][is="thread-card"] .date {
+#threadTree[ac-boldsubjectfrom] tbody > tr[data-properties~="unread"][is="thread-card"] :is(.subject, .sender, .date) {
     font-weight: normal;
 }
 

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -145,8 +145,33 @@
     font-weight: var(--ac-font-weight);
 }
 
-#threadTree tr:is([is="thread-row"], [is="thread-card"]) {
+#threadTree:not([ac-bkgdaslabel-row]) tr[is="thread-row"] {
     background-color: var(--ac-bkgd-color);
+}
+
+#threadTree[ac-bkgdaslabel-row="subjectCol"] tr[is="thread-row"] td.subjectcol-column .thread-container {
+    background-image: linear-gradient(to right, var(--ac-bkgd-color), var(--ac-bkgd-color) var(--ac-row-label-width), transparent var(--ac-row-label-width), transparent 100%);
+    margin-top: 1px;
+    margin-bottom: 1px;
+}
+
+#threadTree[ac-bkgdaslabel-row="firstCol"] tr[is="thread-row"] td.ac-first-non-hidden-column {
+    background-image: linear-gradient(to right, var(--ac-bkgd-color), var(--ac-bkgd-color) var(--ac-row-label-width), transparent var(--ac-row-label-width), transparent 100%);
+    background-clip: content-box;
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+
+#threadTree:not([ac-bkgdaslabel-card]) tr[is="thread-card"] {
+    background-color: var(--ac-bkgd-color);
+}
+
+#threadTree[ac-bkgdaslabel-card="noindent"] tr[is="thread-card"] {
+    background-image: linear-gradient(to right, var(--ac-bkgd-color), var(--ac-bkgd-color) var(--ac-card-label-width), transparent var(--ac-card-label-width), transparent 100%);
+}
+
+#threadTree[ac-bkgdaslabel-card="indent"] tr[is="thread-card"] .thread-card-container {
+    background-image: linear-gradient(to right, var(--ac-bkgd-color), var(--ac-bkgd-color) var(--ac-card-label-width), transparent var(--ac-card-label-width), transparent 100%);
 }
 
 /**********************************************************************************************************************/

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -53,6 +53,14 @@
     color: var(--ac-font-color, var(--folderpane-unread-count-text));
 }
 
+#folderTree li[is="folder-tree-row"] .unread > .container > :is(.unread-count, .total-count, .folder-size) {
+    background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-count-background));
+}
+
+#folderTree li[is="folder-tree-row"] .new-messages > .container > :is(.unread-count, .total-count, .folder-size) {
+    background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-new-count-background));
+}
+
 /**********************************************************************************************************************/
 
 /* Folder Pane - Account Name Font Sizes */

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -47,7 +47,7 @@
     color: var(--ac-font-color, currentColor);
 }
 
-#folderTree li[is="folder-tree-row"] .new-messages > .container > .name {
+#folderTree li[is="folder-tree-row"].new-messages > .container > .name {
     color: var(--ac-font-color, var(--new-folder-color));
 }
 
@@ -55,7 +55,7 @@
     background-color: var(--ac-bkgd-color);
 }
 
-#folderTree li[is="folder-tree-row"] .unread:not(.new-messages) > .container > .unread-count {
+#folderTree li[is="folder-tree-row"].unread:not(.new-messages) > .container > .unread-count {
     color: var(--ac-font-color, var(--folderpane-unread-count-text));
     background-color: var(--ac-badge-bkgd-color, var(--folderpane-unread-count-background));
 }

--- a/chrome/skin/accountcolors-about3pane.css
+++ b/chrome/skin/accountcolors-about3pane.css
@@ -121,7 +121,7 @@
 
 /**********************************************************************************************************************/
 
-/* Thread Pane - Font Colors / Background Colors */
+/* Thread Pane - Font Colors / Background Colors / Font Style / Font Weight */
 
 /* Reinstate default font and background colors for selected and hover rows */
 
@@ -137,6 +137,16 @@
 [is="tree-view-table-body"] tr.selected:focus-within * {
     background-color: inherit !important;
     color: inherit !important;
+}
+
+#threadTree tr[is="thread-row"] > td, #threadTree tr[is="thread-card"] :is(.subject, .sender, .date) {
+    color: var(--ac-font-color);
+    font-style: var(--ac-font-style);
+    font-weight: var(--ac-font-weight);
+}
+
+#threadTree tr:is([is="thread-row"], [is="thread-card"]) {
+    background-color: var(--ac-bkgd-color);
 }
 
 /**********************************************************************************************************************/

--- a/chrome/skin/accountcolors-options.css
+++ b/chrome/skin/accountcolors-options.css
@@ -184,6 +184,7 @@ separator.section {
 #accountcolors-folder-blackrowfont,
 #accountcolors-folder-whiterowfont,
 #accountcolors-folder-colorfldfont,
+#accountcolors-folder-colorother,
 #accountcolors-folder-boldnewmail,
 #accountcolors-folder-showlines,
 #accountcolors-thread-colorfont,

--- a/chrome/skin/accountcolors-options.css
+++ b/chrome/skin/accountcolors-options.css
@@ -373,3 +373,7 @@ div[role="button"] {
 .colorpickertile[selected="true"] {
   border: 2px dotted black;
 }
+
+menulist {
+  margin: 0;
+}

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -74,6 +74,7 @@ pref("extensions.accountcolors.thread-row-label-width", 2);
 pref("extensions.accountcolors.thread-colorbkgd-card-label", false);
 pref("extensions.accountcolors.thread-card-label-position", 0);
 pref("extensions.accountcolors.thread-card-label-width", 4);
+pref("extensions.accountcolors.thread-color-unified-only", false);
 
 /* Message Pane/Tab/Window */
 

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -68,6 +68,12 @@ pref("extensions.accountcolors.thread-showstripes", false);
 pref("extensions.accountcolors.thread-darkerbar", false);
 pref("extensions.accountcolors.thread-incspacing", false);
 pref("extensions.accountcolors.thread-hoverselect", true);
+pref("extensions.accountcolors.thread-colorbkgd-row-label", false);
+pref("extensions.accountcolors.thread-row-label-position", 0);
+pref("extensions.accountcolors.thread-row-label-width", 2);
+pref("extensions.accountcolors.thread-colorbkgd-card-label", false);
+pref("extensions.accountcolors.thread-card-label-position", 0);
+pref("extensions.accountcolors.thread-card-label-width", 4);
 
 /* Message Pane/Tab/Window */
 

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -30,6 +30,7 @@ pref("extensions.accountcolors.folder-colorbkgd", true);
 pref("extensions.accountcolors.folder-colorfldfont", true);
 pref("extensions.accountcolors.folder-colorfldbkgd", true);
 pref("extensions.accountcolors.folder-colorother", false);
+pref("extensions.accountcolors.folder-colorotherbkgd", false);
 pref("extensions.accountcolors.folder-blackrowfont", false);
 pref("extensions.accountcolors.folder-lightpanebkgd", false);
 pref("extensions.accountcolors.folder-whiterowfont", false);

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -95,6 +95,8 @@ pref("extensions.accountcolors.message-blackhdrlabels", false);
 pref("extensions.accountcolors.message-whitehdrlabels", false);
 pref("extensions.accountcolors.message-hdraccount", false);
 pref("extensions.accountcolors.message-defaultbkgd", false);
+pref("extensions.accountcolors.message-colorbkgd-header-label", false);
+pref("extensions.accountcolors.message-header-label-width", 4);
 
 /* Compose Window */
 

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -128,3 +128,7 @@ pref("extensions.accountcolors.compose-defaultbkgd", false);
 pref("extensions.accountcolors.compose-hoverfrom", true);
 pref("extensions.accountcolors.compose-colorbkgd-idmenu-label", false);
 pref("extensions.accountcolors.compose-idmenu-label-width", 4);
+
+/* Fetch received header for better identity resolution */
+
+pref("mailnews.customDBHeaders", "received");

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -42,6 +42,8 @@ pref("extensions.accountcolors.folder-showlines", false);
 pref("extensions.accountcolors.folder-darkerbar", false);
 pref("extensions.accountcolors.folder-incspacing", false);
 pref("extensions.accountcolors.folder-hoverselect", true);
+pref("extensions.accountcolors.folder-colorbkgd-account-icon", false);
+pref("extensions.accountcolors.folder-colorbkgd-folder-icon", false);
 
 /* Thread Pane */
 

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -123,3 +123,5 @@ pref("extensions.accountcolors.compose-whitefieldfont", false);
 pref("extensions.accountcolors.compose-darkfieldbkgd", false);
 pref("extensions.accountcolors.compose-defaultbkgd", false);
 pref("extensions.accountcolors.compose-hoverfrom", true);
+pref("extensions.accountcolors.compose-colorbkgd-idmenu-label", false);
+pref("extensions.accountcolors.compose-idmenu-label-width", 4);

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -28,7 +28,7 @@ pref("extensions.accountcolors.folder-fontsize", 12);
 pref("extensions.accountcolors.folder-colorfont", true);
 pref("extensions.accountcolors.folder-colorbkgd", true);
 pref("extensions.accountcolors.folder-colorfldfont", true);
-pref("extensions.accountcolors.folder-colorfldbkgd", true);
+pref("extensions.accountcolors.folder-colorfldbkgd", false);
 pref("extensions.accountcolors.folder-colorother", false);
 pref("extensions.accountcolors.folder-colorotherbkgd", false);
 pref("extensions.accountcolors.folder-blackrowfont", false);
@@ -43,7 +43,7 @@ pref("extensions.accountcolors.folder-showlines", false);
 pref("extensions.accountcolors.folder-darkerbar", false);
 pref("extensions.accountcolors.folder-incspacing", false);
 pref("extensions.accountcolors.folder-hoverselect", true);
-pref("extensions.accountcolors.folder-colorbkgd-account-icon", false);
+pref("extensions.accountcolors.folder-colorbkgd-account-icon", true);
 pref("extensions.accountcolors.folder-colorbkgd-folder-icon", false);
 
 /* Thread Pane */


### PR DESCRIPTION
This is a feature PR, along with various important bug/style fixes and performance optimizations.

# Features

## Folder Pane

### Render Account Background Color as Icon Color

For account folders, and all subfolders in each Unified Folders (Inbox, Draft, etc.), their background color will be rendered as folder icon's color.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/712e9eeb-1d1e-4fe1-be51-5c5d6d93a009" width="40%">

### Render Folder Background Color as Icon Color

For normal folders, their background color will be rendered as foler icons color (The orange and blue ones). 
  * If any folder is named as one of its identity's email or name (the purple one), that folder and all its subfolders will be rendered with that identity's color.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/83b3e1f2-4607-4c43-b1be-1b515e0c9865" width="40%">

### Color Unread / Total Background

The folder's unread / total messages badge's background can be colored now. 
  * It will not affect new message's background color.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/4aa4f02d-9ab1-418a-ade8-b58609dbc588" width="40%">

## Thread Pane

### Color Row Background as Label in Card View

For each thread pane's card row, their background color will be rendered as a small label in the leftmost of the card.
* The label's width can be configured.
* The label's position can be set to be indented/not indented for thread submessages.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/7de10d9e-eb9d-48ef-9ffa-c26344ad2e11" width="100%">

### Color Row Background as Label in Table View

For each thread pane's table row, their background color will be rendered as a small label in the leftmost of the column.
* The label's width can be configured.
* The label's position can be set to be at subject column, or at first column of the row.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/0d75c252-2fc5-46dc-b3ee-61be8e520c90" width="100%">

## Message Pane

### Color Header Background as Label

Message header's background will be rendered as a small label in the leftmost area.
* The label's width can be configured.

![color-header-background-as-label](https://github.com/gazhay/accountcolors/assets/20227484/331cb9ab-7e58-40cd-b553-66b694ece94a)

## Compose Pane

### Color Identity Background as Label in From Menu

Identity entry's background will be rendered as a small label in the leftmost of the row.
* The label's width can be configured.

<img src="https://github.com/gazhay/accountcolors/assets/20227484/e28a4616-83e4-4cf7-b33f-e07467cecec1" width="60%">

# Fixes and Improvements

* Various CSS styles fixes.
* If any folder is named as one of its identity's email or name (the purple one), that folder and all its subfolders will be rendered with that identity's color.
* Even without enabling `Color based on Received Account (Instead of Folder Account)`, each message will try to use the identity in the folder account that matches the message header.
* Will also try to search for message received header for the actual identity, so can correct color GitHub notifications email, whose receiver is a special group address (<project>@noreply.github.com) instead of account's address.
* Use CSS custom properties to setup font/background color and font/style weight, for better performance.